### PR TITLE
fix(#4): lock invoiced work entries from edit/delete

### DIFF
--- a/src/WorkTracking.UI/Converters/BoolToVisibilityConverter.cs
+++ b/src/WorkTracking.UI/Converters/BoolToVisibilityConverter.cs
@@ -23,3 +23,13 @@ public class InverseBoolToVisibilityConverter : IValueConverter
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         => value is not Visibility.Visible;
 }
+
+[ValueConversion(typeof(bool), typeof(bool))]
+public class InverseBoolConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is not true;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is not true;
+}

--- a/src/WorkTracking.UI/ViewModels/TimesheetViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/TimesheetViewModel.cs
@@ -342,6 +342,16 @@ public class TimesheetViewModel(
         },
         _ => _selectedEntry is not null && !_selectedEntry.IsInvoiced);
 
+    public ICommand ViewEntryCommand => new RelayCommand(
+        _ =>
+        {
+            if (_selectedEntry is null) return;
+            var enabledCategories = CategoriesWithAll.Skip(1).ToList();
+            var vm = new WorkEntryDialogViewModel(enabledCategories, _selectedEntry.Entry, isReadOnly: true);
+            dialogService.ShowWorkEntryDialog(vm);
+        },
+        _ => _selectedEntry is not null);
+
     public event EventHandler? InvoiceCreated;
 
     // --- Data loading ---

--- a/src/WorkTracking.UI/ViewModels/WorkEntryDialogViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/WorkEntryDialogViewModel.cs
@@ -13,10 +13,11 @@ public class WorkEntryDialogViewModel : ViewModelBase
     private string? _notesMarkdown;
     private bool _confirmed;
 
-    public WorkEntryDialogViewModel(IReadOnlyList<WorkCategory> categories, WorkEntry? existing = null)
+    public WorkEntryDialogViewModel(IReadOnlyList<WorkCategory> categories, WorkEntry? existing = null, bool isReadOnly = false)
     {
         Categories = categories;
         IsEdit = existing is not null;
+        IsReadOnly = isReadOnly;
 
         if (existing is not null)
         {
@@ -30,15 +31,16 @@ public class WorkEntryDialogViewModel : ViewModelBase
 
         ConfirmCommand = new RelayCommand(
             _ => { _confirmed = true; CloseRequested?.Invoke(this, EventArgs.Empty); },
-            _ => !string.IsNullOrWhiteSpace(_description) && _hours > 0);
+            _ => !IsReadOnly && !string.IsNullOrWhiteSpace(_description) && _hours > 0);
 
         CancelCommand = new RelayCommand(
             _ => CloseRequested?.Invoke(this, EventArgs.Empty));
     }
 
     public bool IsEdit { get; }
+    public bool IsReadOnly { get; }
     public int ExistingId { get; }
-    public string Title => IsEdit ? "Edit Work Entry" : "Add Work Entry";
+    public string Title => IsReadOnly ? "View Work Entry" : (IsEdit ? "Edit Work Entry" : "Add Work Entry");
     public IReadOnlyList<WorkCategory> Categories { get; }
 
     public DateTime Date

--- a/src/WorkTracking.UI/Views/TimesheetView.xaml
+++ b/src/WorkTracking.UI/Views/TimesheetView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="WorkTracking.UI.Views.TimesheetView"
+﻿<UserControl x:Class="WorkTracking.UI.Views.TimesheetView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -67,6 +67,8 @@
                 <Button Content="✏ Edit" Command="{Binding EditEntryCommand}"
                         Margin="0,0,4,0" Padding="7,2" FontSize="11"/>
                 <Button Content="🗑 Delete" Command="{Binding DeleteEntryCommand}"
+                        Margin="0,0,4,0" Padding="7,2" FontSize="11"/>
+                <Button Content="👁 View" Command="{Binding ViewEntryCommand}"
                         Padding="7,2" FontSize="11"/>
 
                 <Separator Width="1" Height="18" Margin="10,0" Background="#CCC"/>
@@ -98,6 +100,15 @@
                       GridLinesVisibility="Horizontal"
                       HeadersVisibility="Column"
                       BorderThickness="0">
+                <DataGrid.RowStyle>
+                    <Style TargetType="DataGridRow">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsInvoiced}" Value="True">
+                                <Setter Property="Foreground" Value="Gray"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </DataGrid.RowStyle>
                 <DataGrid.GroupStyle>
                     <GroupStyle>
                         <GroupStyle.HeaderTemplate>

--- a/src/WorkTracking.UI/Views/WorkEntryDialog.xaml
+++ b/src/WorkTracking.UI/Views/WorkEntryDialog.xaml
@@ -1,13 +1,20 @@
-<Window x:Class="WorkTracking.UI.Views.WorkEntryDialog"
+﻿<Window x:Class="WorkTracking.UI.Views.WorkEntryDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="clr-namespace:WorkTracking.UI.ViewModels"
+        xmlns:converters="clr-namespace:WorkTracking.UI.Converters"
         mc:Ignorable="d"
         Title="{Binding Title}" Width="440" SizeToContent="Height"
         ResizeMode="NoResize" WindowStartupLocation="CenterOwner"
         d:DataContext="{d:DesignInstance Type=vm:WorkEntryDialogViewModel}">
+
+    <Window.Resources>
+        <converters:InverseBoolConverter x:Key="InverseBoolConverter"/>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+        <converters:InverseBoolToVisibilityConverter x:Key="InverseBoolToVisibilityConverter"/>
+    </Window.Resources>
 
     <StackPanel Margin="20">
 
@@ -28,18 +35,21 @@
             <TextBlock Grid.Row="0" Grid.Column="0" Text="Date *" VerticalAlignment="Center" Margin="0,0,0,10"/>
             <DatePicker Grid.Row="0" Grid.Column="1"
                         SelectedDate="{Binding Date}"
+                        IsEnabled="{Binding IsReadOnly, Converter={StaticResource InverseBoolConverter}}"
                         Margin="0,0,0,10"/>
 
             <!-- Description -->
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Description *" VerticalAlignment="Center" Margin="0,0,0,10"/>
             <TextBox   Grid.Row="1" Grid.Column="1"
                        Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
+                       IsReadOnly="{Binding IsReadOnly}"
                        Margin="0,0,0,10"/>
 
             <!-- Hours -->
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Hours *" VerticalAlignment="Center" Margin="0,0,0,10"/>
             <TextBox   Grid.Row="2" Grid.Column="1"
                        Text="{Binding Hours, UpdateSourceTrigger=PropertyChanged}"
+                       IsReadOnly="{Binding IsReadOnly}"
                        Margin="0,0,0,10"/>
 
             <!-- Category -->
@@ -47,6 +57,7 @@
             <ComboBox  Grid.Row="3" Grid.Column="1"
                        ItemsSource="{Binding Categories}"
                        SelectedItem="{Binding SelectedCategory}"
+                       IsEnabled="{Binding IsReadOnly, Converter={StaticResource InverseBoolConverter}}"
                        DisplayMemberPath="Name"
                        Margin="0,0,0,10"/>
 
@@ -54,14 +65,21 @@
             <TextBlock Grid.Row="4" Grid.Column="0" Text="Notes" VerticalAlignment="Top" Margin="0,4,0,0"/>
             <TextBox   Grid.Row="4" Grid.Column="1"
                        Text="{Binding NotesMarkdown, UpdateSourceTrigger=PropertyChanged}"
+                       IsReadOnly="{Binding IsReadOnly}"
                        AcceptsReturn="True" MinHeight="70" TextWrapping="Wrap"
                        VerticalScrollBarVisibility="Auto"/>
         </Grid>
 
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
-            <Button Content="Cancel" Command="{Binding CancelCommand}" Width="80" Margin="0,0,8,0"/>
+            <!-- Read-only mode: single Close button -->
+            <Button Content="Close" Command="{Binding CancelCommand}" Width="80" IsDefault="True"
+                    Visibility="{Binding IsReadOnly, Converter={StaticResource BoolToVisibilityConverter}}"/>
+            <!-- Edit/Add mode: Cancel + Save -->
+            <Button Content="Cancel" Command="{Binding CancelCommand}" Width="80" Margin="0,0,8,0"
+                    Visibility="{Binding IsReadOnly, Converter={StaticResource InverseBoolToVisibilityConverter}}"/>
             <Button Content="{Binding Title}" Command="{Binding ConfirmCommand}" Width="110"
-                    IsDefault="True"/>
+                    IsDefault="True"
+                    Visibility="{Binding IsReadOnly, Converter={StaticResource InverseBoolToVisibilityConverter}}"/>
         </StackPanel>
     </StackPanel>
 </Window>

--- a/tests/WorkTracking.Tests/UI/TimesheetViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/TimesheetViewModelTests.cs
@@ -269,3 +269,115 @@ public class TimesheetViewModelDeleteConfirmTests
         dialogService.Verify(d => d.Confirm(It.Is<string>(m => m.Contains("Test entry")), It.IsAny<string>()), Times.Once);
     }
 }
+
+// -- Issue #4: Lock invoiced entries from edit/delete -------------------------
+
+public class TimesheetViewModelInvoicedLockTests
+{
+    private static (TimesheetViewModel vm, Mock<IWorkEntryRepository> entryRepo, Mock<IDialogService> dialogService) MakeVm()
+    {
+        var entryRepo = new Mock<IWorkEntryRepository>();
+        var categoryRepo = new Mock<IWorkCategoryRepository>();
+        var invoiceRepo = new Mock<IInvoiceRepository>();
+        var dialogService = new Mock<IDialogService>();
+        categoryRepo.Setup(r => r.GetByClientAsync(It.IsAny<int>())).ReturnsAsync([]);
+        entryRepo.Setup(r => r.GetFilteredAsync(It.IsAny<int>(), null, null, false, null))
+                 .ReturnsAsync([]);
+        var vm = new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, dialogService.Object);
+        return (vm, entryRepo, dialogService);
+    }
+
+    private static WorkEntry MakeEntry(int id, bool invoiced = false) => new()
+    {
+        Id = id, ClientId = 1,
+        Date = DateOnly.FromDateTime(DateTime.Today),
+        Description = "Test entry", Hours = 1m,
+        InvoicedFlag = invoiced
+    };
+
+    [Fact]
+    public async Task EditEntryCommand_WhenEntryIsInvoiced_CanExecuteReturnsFalse()
+    {
+        var (vm, _, _) = MakeVm();
+        await vm.LoadAsync(1, 100m, null);
+        vm.SelectedEntry = new WorkEntryRowViewModel(MakeEntry(1, invoiced: true), null);
+
+        vm.EditEntryCommand.CanExecute(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EditEntryCommand_WhenEntryIsUninvoiced_CanExecuteReturnsTrue()
+    {
+        var (vm, _, _) = MakeVm();
+        await vm.LoadAsync(1, 100m, null);
+        vm.SelectedEntry = new WorkEntryRowViewModel(MakeEntry(1, invoiced: false), null);
+
+        vm.EditEntryCommand.CanExecute(null).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeleteEntryCommand_WhenEntryIsInvoiced_CanExecuteReturnsFalse()
+    {
+        var (vm, _, _) = MakeVm();
+        await vm.LoadAsync(1, 100m, null);
+        vm.SelectedEntry = new WorkEntryRowViewModel(MakeEntry(1, invoiced: true), null);
+
+        vm.DeleteEntryCommand.CanExecute(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeleteEntryCommand_WhenEntryIsUninvoiced_CanExecuteReturnsTrue()
+    {
+        var (vm, _, _) = MakeVm();
+        await vm.LoadAsync(1, 100m, null);
+        vm.SelectedEntry = new WorkEntryRowViewModel(MakeEntry(1, invoiced: false), null);
+
+        vm.DeleteEntryCommand.CanExecute(null).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ViewEntryCommand_WhenNoEntrySelected_CanExecuteReturnsFalse()
+    {
+        var (vm, _, _) = MakeVm();
+        await vm.LoadAsync(1, 100m, null);
+
+        vm.ViewEntryCommand.CanExecute(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ViewEntryCommand_WhenUninvoicedEntrySelected_CanExecuteReturnsTrue()
+    {
+        var (vm, _, _) = MakeVm();
+        await vm.LoadAsync(1, 100m, null);
+        vm.SelectedEntry = new WorkEntryRowViewModel(MakeEntry(1, invoiced: false), null);
+
+        vm.ViewEntryCommand.CanExecute(null).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ViewEntryCommand_WhenInvoicedEntrySelected_CanExecuteReturnsTrue()
+    {
+        var (vm, _, _) = MakeVm();
+        await vm.LoadAsync(1, 100m, null);
+        vm.SelectedEntry = new WorkEntryRowViewModel(MakeEntry(1, invoiced: true), null);
+
+        vm.ViewEntryCommand.CanExecute(null).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ViewEntryCommand_WhenExecuted_OpensDialogInReadOnlyMode()
+    {
+        var (vm, _, dialogService) = MakeVm();
+        WorkEntryDialogViewModel? capturedVm = null;
+        dialogService.Setup(d => d.ShowWorkEntryDialog(It.IsAny<WorkEntryDialogViewModel>()))
+                     .Callback<WorkEntryDialogViewModel>(v => capturedVm = v)
+                     .Returns(false);
+
+        await vm.LoadAsync(1, 100m, null);
+        vm.SelectedEntry = new WorkEntryRowViewModel(MakeEntry(1, invoiced: true), null);
+        vm.ViewEntryCommand.Execute(null);
+
+        capturedVm.Should().NotBeNull();
+        capturedVm!.IsReadOnly.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Implements issue #4 - invoiced work entries are now locked from editing and deletion.

Changes:
- InverseBoolConverter for XAML IsEnabled bindings
- WorkEntryDialogViewModel: IsReadOnly param, Title updated, ConfirmCommand guarded
- WorkEntryDialog.xaml: inputs disabled in read-only mode, Close button replaces Cancel+Save
- TimesheetViewModel: ViewEntryCommand opens dialog in read-only mode
- TimesheetView.xaml: View button in toolbar, gray row style for invoiced entries

8 new tests in TimesheetViewModelInvoicedLockTests. 163/163 passing.

Closes #4