### PR TITLE
fix(#5): work entry category filter on timesheet

### DIFF
--- a/tests/WorkTracking.Tests/Data/WorkEntryRepositoryTests.cs
+++ b/tests/WorkTracking.Tests/Data/WorkEntryRepositoryTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using WorkTracking.Core.Models;
 using WorkTracking.Data.Repositories;
@@ -11,6 +11,7 @@ public class WorkEntryRepositoryTests : IDisposable
     private readonly WorkEntryRepository _repository;
     private readonly ClientRepository _clientRepository;
     private readonly InvoiceRepository _invoiceRepository;
+    private readonly WorkCategoryRepository _categoryRepository;
     private int _clientId;
 
     public WorkEntryRepositoryTests()
@@ -18,6 +19,7 @@ public class WorkEntryRepositoryTests : IDisposable
         _repository = new WorkEntryRepository(_fixture.ConnectionFactory, NullLogger<WorkEntryRepository>.Instance);
         _clientRepository = new ClientRepository(_fixture.ConnectionFactory, NullLogger<ClientRepository>.Instance);
         _invoiceRepository = new InvoiceRepository(_fixture.ConnectionFactory, NullLogger<InvoiceRepository>.Instance);
+        _categoryRepository = new WorkCategoryRepository(_fixture.ConnectionFactory, NullLogger<WorkCategoryRepository>.Instance);
         _clientId = _clientRepository.AddAsync(new Client { Name = "Test Client", HourlyRate = 100m })
             .GetAwaiter().GetResult().Id;
     }
@@ -104,11 +106,42 @@ public class WorkEntryRepositoryTests : IDisposable
         fetched.Should().BeNull();
     }
 
-    private static WorkEntry BuildEntry(int clientId, DateOnly date, decimal hours) => new()
+
+    [Fact]
+    public async Task GetFilteredAsync_ByWorkCategoryId_ReturnsMatchingEntries()
+    {
+        var cat1 = await _categoryRepository.AddAsync(new WorkCategory { Name = "Dev" });
+        var cat2 = await _categoryRepository.AddAsync(new WorkCategory { Name = "Support" });
+        await _repository.AddAsync(BuildEntry(_clientId, new DateOnly(2025, 1, 1), 1m, workCategoryId: cat1.Id));
+        await _repository.AddAsync(BuildEntry(_clientId, new DateOnly(2025, 1, 2), 2m, workCategoryId: cat2.Id));
+        await _repository.AddAsync(BuildEntry(_clientId, new DateOnly(2025, 1, 3), 3m, workCategoryId: cat1.Id));
+
+        var result = await _repository.GetFilteredAsync(_clientId, workCategoryId: cat1.Id);
+
+        result.Should().HaveCount(2);
+        result.Should().AllSatisfy(e => e.WorkCategoryId.Should().Be(cat1.Id));
+    }
+
+    [Fact]
+    public async Task GetFilteredAsync_WithNullCategoryId_ReturnsAllEntries()
+    {
+        var cat1 = await _categoryRepository.AddAsync(new WorkCategory { Name = "Dev" });
+        var cat2 = await _categoryRepository.AddAsync(new WorkCategory { Name = "Support" });
+        await _repository.AddAsync(BuildEntry(_clientId, new DateOnly(2025, 1, 1), 1m, workCategoryId: cat1.Id));
+        await _repository.AddAsync(BuildEntry(_clientId, new DateOnly(2025, 1, 2), 2m, workCategoryId: cat2.Id));
+        await _repository.AddAsync(BuildEntry(_clientId, new DateOnly(2025, 1, 3), 3m));
+
+        var result = await _repository.GetFilteredAsync(_clientId, workCategoryId: null);
+
+        result.Should().HaveCount(3);
+    }
+
+    private static WorkEntry BuildEntry(int clientId, DateOnly date, decimal hours, int? workCategoryId = null) => new()
     {
         ClientId = clientId,
         Date = date,
         Description = "Test work",
         Hours = hours,
+        WorkCategoryId = workCategoryId,
     };
 }

--- a/tests/WorkTracking.Tests/UI/TimesheetViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/TimesheetViewModelTests.cs
@@ -381,3 +381,77 @@ public class TimesheetViewModelInvoicedLockTests
         capturedVm!.IsReadOnly.Should().BeTrue();
     }
 }
+
+// -- Issue #5: Category filter on timesheet ----------------------------------
+
+public class TimesheetViewModelCategoryFilterTests
+{
+    private static (TimesheetViewModel vm, Mock<IWorkEntryRepository> entryRepo, Mock<IWorkCategoryRepository> categoryRepo) MakeVm()
+    {
+        var entryRepo = new Mock<IWorkEntryRepository>();
+        var categoryRepo = new Mock<IWorkCategoryRepository>();
+        var invoiceRepo = new Mock<IInvoiceRepository>();
+        var dialogService = new Mock<IDialogService>();
+        categoryRepo.Setup(r => r.GetByClientAsync(It.IsAny<int>())).ReturnsAsync([]);
+        entryRepo.Setup(r => r.GetFilteredAsync(It.IsAny<int>(), null, null, false, null))
+                 .ReturnsAsync([]);
+        var vm = new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, dialogService.Object);
+        return (vm, entryRepo, categoryRepo);
+    }
+
+    [Fact]
+    public async Task SelectedFilterCategory_WhenSetToSpecificCategory_PassesCategoryIdToRepository()
+    {
+        var (vm, entryRepo, categoryRepo) = MakeVm();
+        var cat = new WorkCategory { Id = 7, Name = "Development" };
+        categoryRepo.Setup(r => r.GetByClientAsync(1)).ReturnsAsync([cat]);
+        entryRepo.Setup(r => r.GetFilteredAsync(1, null, null, false, 7)).ReturnsAsync([]);
+
+        await vm.LoadAsync(1, 100m, null);
+        vm.SelectedFilterCategory = cat;
+
+        entryRepo.Verify(r => r.GetFilteredAsync(1, null, null, false, 7), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task SelectedFilterCategory_WhenResetToAll_PassesNullCategoryToRepository()
+    {
+        var (vm, entryRepo, categoryRepo) = MakeVm();
+        var cat = new WorkCategory { Id = 7, Name = "Development" };
+        var all = new WorkCategory { Id = 0, Name = "All categories" };
+        categoryRepo.Setup(r => r.GetByClientAsync(1)).ReturnsAsync([cat]);
+        entryRepo.Setup(r => r.GetFilteredAsync(1, null, null, false, null)).ReturnsAsync([]);
+        entryRepo.Setup(r => r.GetFilteredAsync(1, null, null, false, 7)).ReturnsAsync([]);
+
+        await vm.LoadAsync(1, 100m, null);
+        vm.SelectedFilterCategory = cat;
+        vm.SelectedFilterCategory = all;
+
+        entryRepo.Verify(r => r.GetFilteredAsync(1, null, null, false, null), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task CategoriesWithAll_AlwaysHasAllCategoriesSentinelFirst()
+    {
+        var (vm, _, categoryRepo) = MakeVm();
+        var cat = new WorkCategory { Id = 3, Name = "Support" };
+        categoryRepo.Setup(r => r.GetByClientAsync(1)).ReturnsAsync([cat]);
+
+        await vm.LoadAsync(1, 100m, null);
+
+        vm.CategoriesWithAll.Should().HaveCount(2);
+        vm.CategoriesWithAll[0].Id.Should().Be(0);
+        vm.CategoriesWithAll[0].Name.Should().Be("All categories");
+        vm.CategoriesWithAll[1].Name.Should().Be("Support");
+    }
+
+    [Fact]
+    public async Task SelectedFilterCategory_DefaultsToAllCategories()
+    {
+        var (vm, _, _) = MakeVm();
+        await vm.LoadAsync(1, 100m, null);
+
+        vm.SelectedFilterCategory.Id.Should().Be(0);
+        vm.SelectedFilterCategory.Name.Should().Be("All categories");
+    }
+}


### PR DESCRIPTION
The category filter was already fully implemented end-to-end. This PR adds the missing test coverage to satisfy the acceptance criteria.

Added tests:
- GetFilteredAsync_ByWorkCategoryId_ReturnsMatchingEntries (repository integration)
- GetFilteredAsync_WithNullCategoryId_ReturnsAllEntries (repository integration)
- SelectedFilterCategory_WhenSetToSpecificCategory_PassesCategoryIdToRepository
- SelectedFilterCategory_WhenResetToAll_PassesNullCategoryToRepository
- CategoriesWithAll_AlwaysHasAllCategoriesSentinelFirst
- SelectedFilterCategory_DefaultsToAllCategories

169/169 tests passing.

Closes #5