### PR TITLE
feat(#12): keyboard-first workflow for fast work entry

### DIFF
--- a/src/WorkTracking.UI/Views/TimesheetView.xaml
+++ b/src/WorkTracking.UI/Views/TimesheetView.xaml
@@ -106,8 +106,9 @@
                       HeadersVisibility="Column"
                       BorderThickness="0">
                 <DataGrid.InputBindings>
-                    <KeyBinding Key="Enter" Command="{Binding AddEntryCommand}"/>
-                    <KeyBinding Key="F2" Command="{Binding AddEntryCommand}"/>
+                    <KeyBinding Key="Insert" Command="{Binding AddEntryCommand}"/>
+                    <KeyBinding Key="F2" Command="{Binding EditEntryCommand}"/>
+                    <KeyBinding Key="Delete" Command="{Binding DeleteEntryCommand}"/>
                 </DataGrid.InputBindings>
                 <DataGrid.RowStyle>
                     <Style TargetType="DataGridRow">

--- a/src/WorkTracking.UI/Views/TimesheetView.xaml
+++ b/src/WorkTracking.UI/Views/TimesheetView.xaml
@@ -13,6 +13,10 @@
         <converters:InverseBoolToVisibilityConverter x:Key="InverseBoolToVisibilityConverter"/>
     </UserControl.Resources>
 
+    <UserControl.InputBindings>
+        <KeyBinding Key="F5" Command="{Binding RefreshCommand}"/>
+    </UserControl.InputBindings>
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -62,8 +66,9 @@
 
                 <Separator Width="1" Height="18" Margin="10,0" Background="#CCC"/>
 
-                <Button Content="+ Add entry" Command="{Binding AddEntryCommand}"
-                        Margin="0,0,4,0" Padding="7,2" FontSize="11"/>
+                <Button Content="+ Add Entry" Command="{Binding AddEntryCommand}"
+                        Margin="0,0,6,0" Padding="12,4" FontSize="12" FontWeight="SemiBold"
+                        Background="#0078D4" Foreground="White" BorderThickness="0"/>
                 <Button Content="✏ Edit" Command="{Binding EditEntryCommand}"
                         Margin="0,0,4,0" Padding="7,2" FontSize="11"/>
                 <Button Content="🗑 Delete" Command="{Binding DeleteEntryCommand}"
@@ -100,6 +105,10 @@
                       GridLinesVisibility="Horizontal"
                       HeadersVisibility="Column"
                       BorderThickness="0">
+                <DataGrid.InputBindings>
+                    <KeyBinding Key="Enter" Command="{Binding AddEntryCommand}"/>
+                    <KeyBinding Key="F2" Command="{Binding AddEntryCommand}"/>
+                </DataGrid.InputBindings>
                 <DataGrid.RowStyle>
                     <Style TargetType="DataGridRow">
                         <Style.Triggers>

--- a/src/WorkTracking.UI/Views/WorkEntryDialog.xaml
+++ b/src/WorkTracking.UI/Views/WorkEntryDialog.xaml
@@ -35,21 +35,21 @@
             <TextBlock Grid.Row="0" Grid.Column="0" Text="Date *" VerticalAlignment="Center" Margin="0,0,0,10"/>
             <DatePicker Grid.Row="0" Grid.Column="1"
                         SelectedDate="{Binding Date}"
-                        IsEnabled="{Binding IsReadOnly, Converter={StaticResource InverseBoolConverter}}"
+                        TabIndex="0" IsEnabled="{Binding IsReadOnly, Converter={StaticResource InverseBoolConverter}}"
                         Margin="0,0,0,10"/>
 
             <!-- Description -->
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Description *" VerticalAlignment="Center" Margin="0,0,0,10"/>
             <TextBox   Grid.Row="1" Grid.Column="1"
                        Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
-                       IsReadOnly="{Binding IsReadOnly}"
+                       TabIndex="1" IsReadOnly="{Binding IsReadOnly}"
                        Margin="0,0,0,10"/>
 
             <!-- Hours -->
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Hours *" VerticalAlignment="Center" Margin="0,0,0,10"/>
             <TextBox   Grid.Row="2" Grid.Column="1"
                        Text="{Binding Hours, UpdateSourceTrigger=PropertyChanged}"
-                       IsReadOnly="{Binding IsReadOnly}"
+                       TabIndex="2" IsReadOnly="{Binding IsReadOnly}"
                        Margin="0,0,0,10"/>
 
             <!-- Category -->
@@ -57,7 +57,7 @@
             <ComboBox  Grid.Row="3" Grid.Column="1"
                        ItemsSource="{Binding Categories}"
                        SelectedItem="{Binding SelectedCategory}"
-                       IsEnabled="{Binding IsReadOnly, Converter={StaticResource InverseBoolConverter}}"
+                       TabIndex="3" IsEnabled="{Binding IsReadOnly, Converter={StaticResource InverseBoolConverter}}"
                        DisplayMemberPath="Name"
                        Margin="0,0,0,10"/>
 
@@ -65,17 +65,17 @@
             <TextBlock Grid.Row="4" Grid.Column="0" Text="Notes" VerticalAlignment="Top" Margin="0,4,0,0"/>
             <TextBox   Grid.Row="4" Grid.Column="1"
                        Text="{Binding NotesMarkdown, UpdateSourceTrigger=PropertyChanged}"
-                       IsReadOnly="{Binding IsReadOnly}"
+                       TabIndex="4" IsReadOnly="{Binding IsReadOnly}"
                        AcceptsReturn="True" MinHeight="70" TextWrapping="Wrap"
                        VerticalScrollBarVisibility="Auto"/>
         </Grid>
 
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
             <!-- Read-only mode: single Close button -->
-            <Button Content="Close" Command="{Binding CancelCommand}" Width="80" IsDefault="True"
+            <Button Content="Close" Command="{Binding CancelCommand}" Width="80" IsDefault="True" IsCancel="True"
                     Visibility="{Binding IsReadOnly, Converter={StaticResource BoolToVisibilityConverter}}"/>
             <!-- Edit/Add mode: Cancel + Save -->
-            <Button Content="Cancel" Command="{Binding CancelCommand}" Width="80" Margin="0,0,8,0"
+            <Button Content="Cancel" Command="{Binding CancelCommand}" Width="80" IsCancel="True" Margin="0,0,8,0"
                     Visibility="{Binding IsReadOnly, Converter={StaticResource InverseBoolToVisibilityConverter}}"/>
             <Button Content="{Binding Title}" Command="{Binding ConfirmCommand}" Width="110"
                     IsDefault="True"


### PR DESCRIPTION
Implements issue #12 keyboard shortcuts and UX improvements.

TimesheetView DataGrid InputBindings:
  Insert -> AddEntryCommand
  F2     -> EditEntryCommand
  Delete -> DeleteEntryCommand

TimesheetView UserControl: F5 -> RefreshCommand

WorkEntryDialog: TabIndex 0-4, IsCancel on Cancel/Close, IsDefault on Save.

Add Entry button styled with accent blue, SemiBold, larger padding.

Note: Enter/F2 were originally mapped to AddEntryCommand but DataGrid intercepts them. Corrected to Insert/F2/Delete per standard grid keyboard conventions.

169/169 tests passing. Closes #12