### PR TITLE
feat(#3): client status badges with live refresh after settings save

### DIFF
--- a/src/WorkTracking.Data/Repositories/Interfaces/IWorkEntryRepository.cs
+++ b/src/WorkTracking.Data/Repositories/Interfaces/IWorkEntryRepository.cs
@@ -13,6 +13,7 @@ public interface IWorkEntryRepository
         bool? invoiced = null,
         int? workCategoryId = null);
     Task<WorkEntry?> GetByIdAsync(int id);
+    Task<Dictionary<int, decimal>> GetUninvoicedHoursByClientAsync();
     Task<WorkEntry> AddAsync(WorkEntry entry);
     Task UpdateAsync(WorkEntry entry);
     Task DeleteAsync(int id);

--- a/src/WorkTracking.Data/Repositories/WorkEntryRepository.cs
+++ b/src/WorkTracking.Data/Repositories/WorkEntryRepository.cs
@@ -12,6 +12,22 @@ public class WorkEntryRepository(IDatabaseConnectionFactory connectionFactory, I
     public async Task<IReadOnlyList<WorkEntry>> GetByClientAsync(int clientId)
         => await GetFilteredAsync(clientId);
 
+    public async Task<Dictionary<int, decimal>> GetUninvoicedHoursByClientAsync()
+    {
+        await using var connection = connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT client_id, SUM(hours) FROM work_entry WHERE invoiced_flag = 0 GROUP BY client_id";
+
+        var result = new Dictionary<int, decimal>();
+        await using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+            result[reader.GetInt32(0)] = (decimal)reader.GetDouble(1);
+
+        return result;
+    }
+
     public async Task<IReadOnlyList<WorkEntry>> GetByInvoiceIdAsync(int invoiceId)
     {
         await using var connection = connectionFactory.CreateConnection();

--- a/src/WorkTracking.UI/MainWindow.xaml
+++ b/src/WorkTracking.UI/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="WorkTracking.UI.MainWindow"
+<Window x:Class="WorkTracking.UI.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -38,7 +38,7 @@
                      Padding="4"
                      x:Name="SearchBox"/>
             <ListBox ItemsSource="{Binding ClientList.Clients}"
-                     SelectedItem="{Binding ClientList.SelectedClient}"
+                     SelectedItem="{Binding ClientList.SelectedRow}"
                      BorderThickness="0"
                      Background="Transparent">
                 <ListBox.ItemTemplate>

--- a/src/WorkTracking.UI/ViewModels/ClientDetailViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/ClientDetailViewModel.cs
@@ -48,6 +48,8 @@ public class ClientDetailViewModel(
         {
             Client = updatedClient;
             OnPropertyChanged(nameof(HasClient));
+            _ = Timesheet.LoadAsync(updatedClient.Id, updatedClient.HourlyRate, updatedClient.InvoiceCapAmount);
+            _ = Summary.LoadAsync(updatedClient);
         };
     }
 

--- a/src/WorkTracking.UI/ViewModels/ClientListViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/ClientListViewModel.cs
@@ -7,13 +7,16 @@ using WorkTracking.UI.Services;
 
 namespace WorkTracking.UI.ViewModels;
 
-public class ClientListViewModel(IClientRepository clientRepository, IDialogService dialogService) : ViewModelBase
+public class ClientListViewModel(
+    IClientRepository clientRepository,
+    IWorkEntryRepository workEntryRepository,
+    IDialogService dialogService) : ViewModelBase
 {
-    private ObservableCollection<Client> _clients = [];
-    private Client? _selectedClient;
+    private ObservableCollection<ClientRowViewModel> _clients = [];
+    private ClientRowViewModel? _selectedRow;
     private string _searchText = string.Empty;
 
-    public ObservableCollection<Client> Clients
+    public ObservableCollection<ClientRowViewModel> Clients
     {
         get => _clients;
         private set
@@ -25,10 +28,22 @@ public class ClientListViewModel(IClientRepository clientRepository, IDialogServ
 
     public bool HasClients => _clients.Count > 0;
 
+    public ClientRowViewModel? SelectedRow
+    {
+        get => _selectedRow;
+        set
+        {
+            if (SetField(ref _selectedRow, value))
+                OnPropertyChanged(nameof(SelectedClient));
+        }
+    }
+
     public Client? SelectedClient
     {
-        get => _selectedClient;
-        set => SetField(ref _selectedClient, value);
+        get => _selectedRow?.Client;
+        set => SelectedRow = value is null ? null
+            : _allClients.FirstOrDefault(r => r.Client.Id == value.Id)
+              ?? new ClientRowViewModel(value, 0);
     }
 
     public string SearchText
@@ -57,25 +72,31 @@ public class ClientListViewModel(IClientRepository clientRepository, IDialogServ
         };
         var added = await clientRepository.AddAsync(client);
         await LoadAsync();
-        SelectedClient = _allClients.FirstOrDefault(c => c.Id == added.Id);
+        SelectedClient = _allClients.FirstOrDefault(r => r.Client.Id == added.Id)?.Client;
     });
 
     public ICommand DeleteClientCommand => new RelayCommand(
         async _ =>
         {
-            if (_selectedClient is null) return;
-            if (!dialogService.Confirm($"Delete client '{_selectedClient.Name}'? This cannot be undone.", "Delete Client"))
+            if (SelectedClient is null) return;
+            if (!dialogService.Confirm($"Delete client '{SelectedClient.Name}'? This cannot be undone.", "Delete Client"))
                 return;
-            await clientRepository.DeleteAsync(_selectedClient.Id);
+            await clientRepository.DeleteAsync(SelectedClient.Id);
             await LoadAsync();
         },
-        _ => _selectedClient is not null);
+        _ => SelectedClient is not null);
 
-    private List<Client> _allClients = [];
+    private List<ClientRowViewModel> _allClients = [];
 
     public async Task LoadAsync()
     {
-        _allClients = [.. await clientRepository.GetAllAsync()];
+        var clients = await clientRepository.GetAllAsync();
+        var hoursByClient = await workEntryRepository.GetUninvoicedHoursByClientAsync();
+
+        _allClients = clients
+            .Select(c => new ClientRowViewModel(c, hoursByClient.GetValueOrDefault(c.Id)))
+            .ToList();
+
         ApplyFilter();
     }
 
@@ -83,7 +104,7 @@ public class ClientListViewModel(IClientRepository clientRepository, IDialogServ
     {
         var filtered = string.IsNullOrWhiteSpace(SearchText)
             ? _allClients
-            : _allClients.Where(c => c.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase)).ToList();
+            : _allClients.Where(r => r.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase)).ToList();
 
         Clients = [.. filtered];
     }

--- a/src/WorkTracking.UI/ViewModels/ClientRowViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/ClientRowViewModel.cs
@@ -1,0 +1,24 @@
+using WorkTracking.Core.Enums;
+using WorkTracking.Core.Models;
+using WorkTracking.Core.Services;
+
+namespace WorkTracking.UI.ViewModels;
+
+public class ClientRowViewModel(Client client, decimal uninvoicedHours)
+{
+    public Client Client => client;
+    public string Name => client.Name;
+    public string? CompanyName => client.CompanyName;
+
+    public bool IsCapExceeded =>
+        InvoiceCapCalculator.Calculate(
+            client.InvoiceCapAmount,
+            uninvoicedHours * client.HourlyRate)
+        == InvoiceCapStatus.OverCap;
+
+    public bool IsInvoiceOverdue =>
+        InvoiceFrequencyCalculator.CalculateStatus(
+            client.NextInvoiceDueDate,
+            DateOnly.FromDateTime(DateTime.Today))
+        == InvoiceFrequencyStatus.Overdue;
+}

--- a/src/WorkTracking.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/MainWindowViewModel.cs
@@ -18,6 +18,12 @@ public class MainWindowViewModel(
             if (e.PropertyName == nameof(ClientListViewModel.SelectedClient))
                 OnSelectedClientChanged(ClientList.SelectedClient);
         };
+
+        ClientDetail.Settings.ClientUpdated += async (_, updatedClient) =>
+        {
+            await ClientList.LoadAsync();
+            ClientList.SelectedClient = updatedClient;
+        };
     }
 
     private void OnSelectedClientChanged(Client? client)

--- a/tests/WorkTracking.Tests/UI/ClientListViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/ClientListViewModelTests.cs
@@ -23,8 +23,15 @@ public class ClientListViewModelTests
         return mock;
     }
 
-    private static ClientListViewModel MakeVm(List<Client> clients) =>
-        new(RepoWith(clients).Object, new Mock<IDialogService>().Object);
+    private static Mock<IWorkEntryRepository> WorkEntryRepoWithHours(Dictionary<int, decimal>? hours = null)
+    {
+        var mock = new Mock<IWorkEntryRepository>();
+        mock.Setup(r => r.GetUninvoicedHoursByClientAsync()).ReturnsAsync(hours ?? []);
+        return mock;
+    }
+
+    private static ClientListViewModel MakeVm(List<Client> clients, Dictionary<int, decimal>? hours = null) =>
+        new(RepoWith(clients).Object, WorkEntryRepoWithHours(hours).Object, new Mock<IDialogService>().Object);
 
     [Fact]
     public async Task LoadAsync_WithClients_PopulatesClients()
@@ -87,11 +94,93 @@ public class ClientListViewModelTests
         await vm.LoadAsync();
         var raised = new List<string?>();
         vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
-        var client = vm.Clients[0];
+        var row = vm.Clients[0];
 
-        vm.SelectedClient = client;
+        vm.SelectedClient = row.Client;
 
-        vm.SelectedClient.Should().Be(client);
+        vm.SelectedClient.Should().Be(row.Client);
         raised.Should().Contain(nameof(ClientListViewModel.SelectedClient));
+    }
+
+    [Fact]
+    public async Task IsCapExceeded_WhenUninvoicedTotalExceedsCap_IsTrue()
+    {
+        var clients = new List<Client>
+        {
+            new() { Id = 1, Name = "CapClient", HourlyRate = 100, InvoiceCapAmount = 500 }
+        };
+        // 6 hours * $100 = $600 > $500 cap
+        var vm = MakeVm(clients, new Dictionary<int, decimal> { [1] = 6m });
+        await vm.LoadAsync();
+
+        vm.Clients[0].IsCapExceeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsCapExceeded_WhenUninvoicedTotalUnderCap_IsFalse()
+    {
+        var clients = new List<Client>
+        {
+            new() { Id = 1, Name = "CapClient", HourlyRate = 100, InvoiceCapAmount = 500 }
+        };
+        // 4 hours * $100 = $400 < $500 cap
+        var vm = MakeVm(clients, new Dictionary<int, decimal> { [1] = 4m });
+        await vm.LoadAsync();
+
+        vm.Clients[0].IsCapExceeded.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsCapExceeded_WhenNoCap_IsFalse()
+    {
+        var clients = new List<Client>
+        {
+            new() { Id = 1, Name = "NoCap", HourlyRate = 100, InvoiceCapAmount = null }
+        };
+        var vm = MakeVm(clients, new Dictionary<int, decimal> { [1] = 100m });
+        await vm.LoadAsync();
+
+        vm.Clients[0].IsCapExceeded.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsInvoiceOverdue_WhenNextDueDateInPast_IsTrue()
+    {
+        var clients = new List<Client>
+        {
+            new() { Id = 1, Name = "OverdueClient", HourlyRate = 100,
+                NextInvoiceDueDate = DateOnly.FromDateTime(DateTime.Today.AddDays(-1)) }
+        };
+        var vm = MakeVm(clients);
+        await vm.LoadAsync();
+
+        vm.Clients[0].IsInvoiceOverdue.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsInvoiceOverdue_WhenNextDueDateInFuture_IsFalse()
+    {
+        var clients = new List<Client>
+        {
+            new() { Id = 1, Name = "OnTrackClient", HourlyRate = 100,
+                NextInvoiceDueDate = DateOnly.FromDateTime(DateTime.Today.AddDays(7)) }
+        };
+        var vm = MakeVm(clients);
+        await vm.LoadAsync();
+
+        vm.Clients[0].IsInvoiceOverdue.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsInvoiceOverdue_WhenNoNextDueDate_IsFalse()
+    {
+        var clients = new List<Client>
+        {
+            new() { Id = 1, Name = "NoFreqClient", HourlyRate = 100, NextInvoiceDueDate = null }
+        };
+        var vm = MakeVm(clients);
+        await vm.LoadAsync();
+
+        vm.Clients[0].IsInvoiceOverdue.Should().BeFalse();
     }
 }

--- a/tests/WorkTracking.Tests/UI/CrudViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/CrudViewModelTests.cs
@@ -61,8 +61,12 @@ public class ClientListViewModelCrudTests
 {
     private static ClientListViewModel MakeVm(
         Mock<IClientRepository> repo,
-        Mock<IDialogService> dialog) =>
-        new(repo.Object, dialog.Object);
+        Mock<IDialogService> dialog)
+    {
+        var workEntryMock = new Mock<IWorkEntryRepository>();
+        workEntryMock.Setup(r => r.GetUninvoicedHoursByClientAsync()).ReturnsAsync(new Dictionary<int, decimal>());
+        return new(repo.Object, workEntryMock.Object, dialog.Object);
+    }
 
     [Fact]
     public async Task AddClientCommand_WhenDialogConfirmed_AddsAndReloads()

--- a/tests/WorkTracking.Tests/UI/MainWindowViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/MainWindowViewModelTests.cs
@@ -13,7 +13,9 @@ public class MainWindowViewModelTests
     {
         var mock = new Mock<IClientRepository>();
         mock.Setup(r => r.GetAllAsync()).ReturnsAsync(clients ?? []);
-        return new ClientListViewModel(mock.Object, new Mock<IDialogService>().Object);
+        var workEntryMock = new Mock<IWorkEntryRepository>();
+        workEntryMock.Setup(r => r.GetUninvoicedHoursByClientAsync()).ReturnsAsync(new Dictionary<int, decimal>());
+        return new ClientListViewModel(mock.Object, workEntryMock.Object, new Mock<IDialogService>().Object);
     }
 
     private static TimesheetViewModel MakeTimesheetVm()

--- a/tests/WorkTracking.Tests/UI/Phase8Tests.cs
+++ b/tests/WorkTracking.Tests/UI/Phase8Tests.cs
@@ -15,7 +15,9 @@ public class ClientListViewModelEmptyStateTests
     {
         var repo = new Mock<IClientRepository>();
         repo.Setup(r => r.GetAllAsync()).ReturnsAsync(clients);
-        return new ClientListViewModel(repo.Object, new Mock<IDialogService>().Object);
+        var workEntryMock = new Mock<IWorkEntryRepository>();
+        workEntryMock.Setup(r => r.GetUninvoicedHoursByClientAsync()).ReturnsAsync(new Dictionary<int, decimal>());
+        return new ClientListViewModel(repo.Object, workEntryMock.Object, new Mock<IDialogService>().Object);
     }
 
     [Fact]
@@ -200,7 +202,7 @@ public class WorkEntryRowViewModelMonthLabelTests
 }
 
 
-// -- WorkEntryRowViewModel — IsInvoiced is read-only --------------------------
+// -- WorkEntryRowViewModel ï¿½ IsInvoiced is read-only --------------------------
 // Regression: WPF DataGridCheckBoxColumn binds TwoWay by default, which throws
 // InvalidOperationException when the property has no setter. IsInvoiced must
 // remain a computed read-only property (no public setter).


### PR DESCRIPTION
Closes #3

## Changes

- Added `ClientRowViewModel` with computed `IsCapExceeded` and `IsInvoiceOverdue` properties driven by `GetUninvoicedHoursByClientAsync()`\n- `ClientListViewModel` uses `ClientRowViewModel` as the list item type and exposes `SelectedRow` for the `ListBox` binding\n- Fixed `MainWindow.xaml`: `SelectedItem` now targets `SelectedRow` instead of `SelectedClient`, eliminating the WPF ConvertBack binding error on client selection\n- `ClientDetailViewModel` reloads `Timesheet` and `Summary` immediately when settings are saved, so cap/rate changes reflect without switching tabs\n- `MainWindowViewModel` reloads the sidebar client list after a settings save, so `IsCapExceeded`/`IsInvoiceOverdue` badges update without switching clients

## Tests

- Unit tests for `IsCapExceeded` (over/under/no cap) and `IsInvoiceOverdue` (past/future/no date) via `ClientListViewModelTests`\n- All 175 tests pass