### PR TITLE
feat(#19): rename confirm buttons to Save with accent styling

### DIFF
--- a/src/WorkTracking.UI/Views/AddClientDialog.xaml
+++ b/src/WorkTracking.UI/Views/AddClientDialog.xaml
@@ -39,8 +39,8 @@
 
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
             <Button Content="Cancel" Command="{Binding CancelCommand}" Width="80" Margin="0,0,8,0"/>
-            <Button Content="Add client" Command="{Binding ConfirmCommand}" Width="90"
-                    IsDefault="True"/>
+            <Button Content="Save" Command="{Binding ConfirmCommand}" Width="80"
+                    IsDefault="True" Background="#0078D4" Foreground="White" FontWeight="SemiBold"/>
         </StackPanel>
     </StackPanel>
 </Window>

--- a/src/WorkTracking.UI/Views/InvoicePrepDialog.xaml
+++ b/src/WorkTracking.UI/Views/InvoicePrepDialog.xaml
@@ -111,10 +111,10 @@
             <Button Content="Cancel"
                     Command="{Binding CancelCommand}"
                     Padding="16,6" Margin="0,0,8,0"/>
-            <Button Content="Create Invoice"
+            <Button Content="Save"
                     Command="{Binding ConfirmCommand}"
                     Padding="16,6"
-                    IsDefault="True"/>
+                    IsDefault="True" Background="#0078D4" Foreground="White" FontWeight="SemiBold"/>
         </StackPanel>
 
     </StackPanel>

--- a/src/WorkTracking.UI/Views/WorkEntryDialog.xaml
+++ b/src/WorkTracking.UI/Views/WorkEntryDialog.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="WorkTracking.UI.Views.WorkEntryDialog"
+<Window x:Class="WorkTracking.UI.Views.WorkEntryDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -77,7 +77,7 @@
             <!-- Edit/Add mode: Cancel + Save -->
             <Button Content="Cancel" Command="{Binding CancelCommand}" Width="80" IsCancel="True" Margin="0,0,8,0"
                     Visibility="{Binding IsReadOnly, Converter={StaticResource InverseBoolToVisibilityConverter}}"/>
-            <Button Content="{Binding Title}" Command="{Binding ConfirmCommand}" Width="110"
+            <Button Content="Save" Command="{Binding ConfirmCommand}" Width="80" Background="#0078D4" Foreground="White" FontWeight="SemiBold"
                     IsDefault="True"
                     Visibility="{Binding IsReadOnly, Converter={StaticResource InverseBoolToVisibilityConverter}}"/>
         </StackPanel>


### PR DESCRIPTION
Closes #19

## Changes

- **WorkEntryDialog**: confirm button renamed from `{Binding Title}` to `Save`, accent styled`n- **AddClientDialog**: confirm button renamed from `Add client` to `Save`, accent styled
- **InvoicePrepDialog**: confirm button renamed from `Create Invoice` to `Save`, accent styled

All three buttons now use `Background=#0078D4 Foreground=White FontWeight=SemiBold` matching the Add Entry toolbar button.

## Tests

175/175 passing — no existing tests affected.