### PR TITLE
fix(#23): Escape key now closes AddClient and InvoicePrep dialogs

### DIFF
--- a/src/WorkTracking.UI/Views/AddClientDialog.xaml
+++ b/src/WorkTracking.UI/Views/AddClientDialog.xaml
@@ -38,7 +38,7 @@
                    Foreground="Gray" FontSize="11" TextWrapping="Wrap" Margin="0,12,0,0"/>
 
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
-            <Button Content="Cancel" Command="{Binding CancelCommand}" Width="80" Margin="0,0,8,0"/>
+            <Button Content="Cancel" Command="{Binding CancelCommand}" Width="80" IsCancel="True" Margin="0,0,8,0"/>
             <Button Content="Save" Command="{Binding ConfirmCommand}" Width="80"
                     IsDefault="True" Background="#0078D4" Foreground="White" FontWeight="SemiBold"/>
         </StackPanel>

--- a/src/WorkTracking.UI/Views/InvoicePrepDialog.xaml
+++ b/src/WorkTracking.UI/Views/InvoicePrepDialog.xaml
@@ -110,7 +110,7 @@
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
             <Button Content="Cancel"
                     Command="{Binding CancelCommand}"
-                    Padding="16,6" Margin="0,0,8,0"/>
+                    Padding="16,6" Margin="0,0,8,0" IsCancel="True"/>
             <Button Content="Save"
                     Command="{Binding ConfirmCommand}"
                     Padding="16,6"


### PR DESCRIPTION
Closes #23

## Root cause

The Cancel buttons in `AddClientDialog` and `InvoicePrepDialog` were missing `IsCancel=True`. WPF only wires Escape to a button when that attribute is present. `WorkEntryDialog` already had it correctly on both its Cancel and Close buttons.

## Changes

- `AddClientDialog.xaml`: added `IsCancel=True` to Cancel button
- `InvoicePrepDialog.xaml`: added `IsCancel=True` to Cancel button

## Tests

175/175 passing.