### PR TITLE
feat: home dashboard and global reports

### DIFF
--- a/src/WorkTracking.UI/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/WorkTracking.UI/DependencyInjection/ServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<ClientSettingsViewModel>();
         services.AddTransient<ClientListViewModel>();
         services.AddTransient<ClientDetailViewModel>();
+        services.AddTransient<HomeViewModel>();
         services.AddTransient<MainWindowViewModel>();
 
         // Main window (Singleton — one instance)

--- a/src/WorkTracking.UI/MainWindow.xaml
+++ b/src/WorkTracking.UI/MainWindow.xaml
@@ -33,6 +33,12 @@
                             Padding="8,4" FontSize="12"/>
                 </Grid>
             </Border>
+            <!-- About button pinned to the bottom -->
+            <Button DockPanel.Dock="Bottom"
+                    Content="About Billable"
+                    Command="{Binding ShowAboutCommand}"
+                    Style="{StaticResource SecondaryButton}"
+                    Margin="8,4,8,8" FontSize="11"/>
             <TextBox DockPanel.Dock="Top"
                      Text="{Binding ClientList.SearchText, UpdateSourceTrigger=PropertyChanged}"
                      Margin="8,0,8,6"
@@ -67,29 +73,44 @@
                       HorizontalAlignment="Stretch"
                       Background="{StaticResource BorderBrush}"/>
 
-        <!-- Right: client detail -->
+        <!-- Right: client detail or home dashboard -->
         <Grid Grid.Column="2">
-            <!-- No client selected -->
-            <TextBlock Text="Select a client to get started."
-                       HorizontalAlignment="Center"
-                       VerticalAlignment="Center"
-                       Foreground="Gray" FontSize="14"
-                       Visibility="{Binding ClientDetail.HasClient,
-                           Converter={StaticResource InverseBoolToVisibilityConverter}}"/>
+            <!-- Home dashboard (no client selected) -->
+            <Grid Visibility="{Binding ShowHome, Converter={StaticResource BoolToVisibilityConverter}}">
+                <views:HomeView DataContext="{Binding Home}"/>
+            </Grid>
 
             <!-- Client detail tabs -->
-            <DockPanel Visibility="{Binding ClientDetail.HasClient,
-                           Converter={StaticResource BoolToVisibilityConverter}}">
-                <Grid DockPanel.Dock="Top" Margin="16,14,16,6">
+            <DockPanel Visibility="{Binding ShowHome,
+                           Converter={StaticResource InverseBoolToVisibilityConverter}}">
+                <Grid DockPanel.Dock="Top" Margin="16,10,16,6">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock Grid.Column="0"
+
+                    <!-- Breadcrumb back link -->
+                    <Button Grid.Row="0" Grid.Column="0"
+                            Content="← Overview"
+                            Command="{Binding GoHomeCommand}"
+                            Style="{StaticResource SecondaryButton}"
+                            HorizontalAlignment="Left"
+                            Padding="0,0" FontSize="11"
+                            BorderThickness="0"
+                            Background="Transparent"
+                            Foreground="{StaticResource TextSecondaryBrush}"
+                            Margin="0,0,0,2"/>
+
+                    <!-- Client name -->
+                    <TextBlock Grid.Row="1" Grid.Column="0"
                                Text="{Binding ClientDetail.Client.Name}"
                                FontSize="18" FontWeight="Bold"
                                VerticalAlignment="Center"/>
-                    <Button Grid.Column="1" Content="Delete client"
+                    <Button Grid.Row="1" Grid.Column="1" Content="Delete client"
                             Command="{Binding ClientList.DeleteClientCommand}"
                             Style="{StaticResource DangerButton}"/>
                 </Grid>

--- a/src/WorkTracking.UI/MainWindow.xaml.cs
+++ b/src/WorkTracking.UI/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Media.Imaging;
+using WorkTracking.UI.ViewModels;
 
 namespace WorkTracking.UI;
 
@@ -10,5 +11,21 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         Icon = BitmapFrame.Create(new Uri("pack://application:,,,/app-icon.png", UriKind.Absolute));
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        if (e.OldValue is MainWindowViewModel oldVm)
+            oldVm.ShowAboutRequested -= OnShowAboutRequested;
+        if (e.NewValue is MainWindowViewModel newVm)
+            newVm.ShowAboutRequested += OnShowAboutRequested;
+    }
+
+    private void OnShowAboutRequested(object? sender, EventArgs e)
+    {
+        var splash = new SplashWindow(canClose: true);
+        splash.Owner = this;
+        splash.ShowDialog();
     }
 }

--- a/src/WorkTracking.UI/SplashWindow.xaml
+++ b/src/WorkTracking.UI/SplashWindow.xaml
@@ -11,12 +11,28 @@
 
     <Border Background="#FF0067C0"
             CornerRadius="12"
-            MouseLeftButtonDown="OnClick">
+            MouseLeftButtonDown="OnBorderClick">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
+
+            <!-- Close button (visible only in About mode) -->
+            <Button x:Name="CloseButton"
+                    Grid.Row="0"
+                    Content="✕"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    Margin="0,10,12,0"
+                    Width="28" Height="28"
+                    FontSize="14"
+                    Foreground="White"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    Cursor="Hand"
+                    Visibility="Collapsed"
+                    Click="OnClick"/>
 
             <!-- Logo -->
             <Image Grid.Row="0"

--- a/src/WorkTracking.UI/SplashWindow.xaml.cs
+++ b/src/WorkTracking.UI/SplashWindow.xaml.cs
@@ -7,9 +7,14 @@ namespace WorkTracking.UI;
 
 public partial class SplashWindow : Window
 {
-    public SplashWindow()
+    private readonly bool _canClose;
+
+    public SplashWindow(bool canClose = false)
     {
         InitializeComponent();
+        _canClose = canClose;
+        CloseButton.Visibility = canClose ? Visibility.Visible : Visibility.Collapsed;
+
         var version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion
                       ?? "dev";
         VersionText.Text = $"v{version}";
@@ -18,8 +23,12 @@ public partial class SplashWindow : Window
     protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
     {
         base.OnMouseLeftButtonDown(e);
-        Close();
+        // In splash mode (not About), any click closes the window
+        if (!_canClose)
+            Close();
     }
 
-    private void OnClick(object sender, MouseButtonEventArgs e) => Close();
+    private void OnBorderClick(object sender, MouseButtonEventArgs e) { /* handled by OnMouseLeftButtonDown */ }
+
+    private void OnClick(object sender, RoutedEventArgs e) => Close();
 }

--- a/src/WorkTracking.UI/ViewModels/ClientStatusRowViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/ClientStatusRowViewModel.cs
@@ -1,0 +1,43 @@
+using WorkTracking.Core.Enums;
+using WorkTracking.Core.Models;
+using WorkTracking.Core.Services;
+
+namespace WorkTracking.UI.ViewModels;
+
+public class ClientStatusRowViewModel(Client client, decimal uninvoicedHours, DateOnly today)
+{
+    public Client Client => client;
+    public string Name => client.Name;
+    public decimal UninvoicedHours => uninvoicedHours;
+    public decimal UninvoicedAmount => uninvoicedHours * client.HourlyRate;
+
+    public bool HasCap => client.InvoiceCapAmount is > 0;
+
+    public double CapProgress =>
+        HasCap ? (double)Math.Min(1m, UninvoicedAmount / client.InvoiceCapAmount!.Value) : 0d;
+
+    public bool IsOverCap =>
+        InvoiceCapCalculator.Calculate(client.InvoiceCapAmount, UninvoicedAmount) == InvoiceCapStatus.OverCap;
+
+    public bool HasFrequency => client.NextInvoiceDueDate.HasValue;
+
+    public string NextDueLabel
+    {
+        get
+        {
+            if (client.NextInvoiceDueDate is null) return string.Empty;
+            var daysUntil = client.NextInvoiceDueDate.Value.DayNumber - today.DayNumber;
+            return daysUntil switch
+            {
+                < 0  => "Overdue",
+                0    => "Due today",
+                1    => "Due tomorrow",
+                _    => $"Due in {daysUntil} days"
+            };
+        }
+    }
+
+    public bool IsOverdue =>
+        InvoiceFrequencyCalculator.CalculateStatus(client.NextInvoiceDueDate, today)
+            == InvoiceFrequencyStatus.Overdue;
+}

--- a/src/WorkTracking.UI/ViewModels/HomeViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/HomeViewModel.cs
@@ -1,0 +1,153 @@
+using System.Collections.ObjectModel;
+using WorkTracking.Core.Models;
+using WorkTracking.Data.Repositories.Interfaces;
+
+namespace WorkTracking.UI.ViewModels;
+
+public record MonthlyReportLine(string Month, decimal Hours, decimal InvoicedAmount);
+public record ClientHourLine(string ClientName, decimal Hours);
+
+public class HomeViewModel(
+    IClientRepository clientRepository,
+    IWorkEntryRepository workEntryRepository,
+    IInvoiceRepository invoiceRepository,
+    IWorkCategoryRepository workCategoryRepository) : ViewModelBase
+{
+    private decimal _totalUnbilledHours;
+    private decimal _invoicedRolling30Days;
+    private int _activeClientCount;
+    private bool _isLoading;
+    private IReadOnlyList<ClientStatusRowViewModel> _clientStatuses = [];
+    private IReadOnlyList<MonthlyReportLine> _monthlyReport = [];
+    private IReadOnlyList<CategoryHourLine> _categoryDistribution = [];
+    private IReadOnlyList<ClientHourLine> _hoursByClient = [];
+
+    public decimal TotalUnbilledHours
+    {
+        get => _totalUnbilledHours;
+        private set => SetField(ref _totalUnbilledHours, value);
+    }
+
+    public decimal InvoicedRolling30Days
+    {
+        get => _invoicedRolling30Days;
+        private set => SetField(ref _invoicedRolling30Days, value);
+    }
+
+    public int ActiveClientCount
+    {
+        get => _activeClientCount;
+        private set => SetField(ref _activeClientCount, value);
+    }
+
+    public bool IsLoading
+    {
+        get => _isLoading;
+        set => SetField(ref _isLoading, value);
+    }
+
+    public IReadOnlyList<ClientStatusRowViewModel> ClientStatuses
+    {
+        get => _clientStatuses;
+        private set => SetField(ref _clientStatuses, value);
+    }
+
+    public IReadOnlyList<MonthlyReportLine> MonthlyReport
+    {
+        get => _monthlyReport;
+        private set => SetField(ref _monthlyReport, value);
+    }
+
+    public IReadOnlyList<CategoryHourLine> CategoryDistribution
+    {
+        get => _categoryDistribution;
+        private set => SetField(ref _categoryDistribution, value);
+    }
+
+    public IReadOnlyList<ClientHourLine> HoursByClient
+    {
+        get => _hoursByClient;
+        private set => SetField(ref _hoursByClient, value);
+    }
+
+    public async Task LoadAsync()
+    {
+        IsLoading = true;
+        try
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var thirtyDaysAgo = today.AddDays(-30);
+
+            var clients = await clientRepository.GetAllAsync();
+            ActiveClientCount = clients.Count;
+
+            // Load uninvoiced hours in one query
+            var uninvoicedByClient = await workEntryRepository.GetUninvoicedHoursByClientAsync();
+            TotalUnbilledHours = uninvoicedByClient.Values.Sum();
+
+            // Load all entries and invoices per client in parallel
+            var entryTasks   = clients.Select(c => workEntryRepository.GetByClientAsync(c.Id)).ToArray();
+            var invoiceTasks = clients.Select(c => invoiceRepository.GetByClientAsync(c.Id)).ToArray();
+            await Task.WhenAll([.. entryTasks, .. invoiceTasks]);
+
+            var allEntries  = entryTasks.SelectMany(t => t.Result).ToList();
+            var allInvoices = invoiceTasks.SelectMany(t => t.Result).ToList();
+
+            // Rolling 30-day invoiced total
+            InvoicedRolling30Days = allInvoices
+                .Where(i => i.InvoiceDate >= thirtyDaysAgo)
+                .Sum(i => i.TotalAmount);
+
+            // Per-client status rows
+            ClientStatuses = clients
+                .Select(c =>
+                {
+                    uninvoicedByClient.TryGetValue(c.Id, out var hours);
+                    return new ClientStatusRowViewModel(c, hours, today);
+                })
+                .ToList();
+
+            // Monthly report: last 12 rolling months
+            MonthlyReport = Enumerable.Range(0, 12)
+                .Select(i =>
+                {
+                    var month = today.AddMonths(-11 + i);
+                    var label = new DateOnly(month.Year, month.Month, 1).ToString("MMM yyyy");
+                    var hours = allEntries
+                        .Where(e => e.Date.Year == month.Year && e.Date.Month == month.Month)
+                        .Sum(e => e.Hours);
+                    var invoiced = allInvoices
+                        .Where(inv => inv.InvoiceDate.Year == month.Year && inv.InvoiceDate.Month == month.Month)
+                        .Sum(inv => inv.TotalAmount);
+                    return new MonthlyReportLine(label, hours, invoiced);
+                })
+                .ToList();
+
+            // Hours by client (all time)
+            var clientNameLookup = clients.ToDictionary(c => c.Id, c => c.Name);
+            HoursByClient = allEntries
+                .GroupBy(e => e.ClientId)
+                .Select(g => new ClientHourLine(
+                    clientNameLookup.TryGetValue(g.Key, out var name) ? name : "Unknown",
+                    g.Sum(e => e.Hours)))
+                .OrderByDescending(l => l.Hours)
+                .ToList();
+
+            // Cross-client category distribution
+            var allCategories = await workCategoryRepository.GetAllAsync();
+            var categoryLookup = allCategories.ToDictionary(c => c.Id, c => c.Name);
+            CategoryDistribution = allEntries
+                .GroupBy(e => e.WorkCategoryId)
+                .Select(g => new CategoryHourLine(
+                    g.Key.HasValue && categoryLookup.TryGetValue(g.Key.Value, out var catName)
+                        ? catName : "Uncategorised",
+                    g.Sum(e => e.Hours)))
+                .OrderByDescending(l => l.Hours)
+                .ToList();
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+}

--- a/src/WorkTracking.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/MainWindowViewModel.cs
@@ -1,17 +1,29 @@
+using System.Windows.Input;
 using WorkTracking.Core.Models;
+using WorkTracking.UI.Commands;
 
 namespace WorkTracking.UI.ViewModels;
 
 public class MainWindowViewModel(
     ClientListViewModel clientListViewModel,
-    ClientDetailViewModel clientDetailViewModel) : ViewModelBase
+    ClientDetailViewModel clientDetailViewModel,
+    HomeViewModel homeViewModel) : ViewModelBase
 {
     public ClientListViewModel ClientList { get; } = clientListViewModel;
     public ClientDetailViewModel ClientDetail { get; } = clientDetailViewModel;
+    public HomeViewModel Home { get; } = homeViewModel;
+
+    public bool ShowHome => ClientList.SelectedClient is null;
+
+    public event EventHandler? ShowAboutRequested;
+
+    public ICommand ShowAboutCommand => new RelayCommand(_ => ShowAboutRequested?.Invoke(this, EventArgs.Empty));
+    public ICommand GoHomeCommand    => new RelayCommand(_ => ClientList.SelectedClient = null);
 
     public async Task InitializeAsync()
     {
         await ClientList.LoadAsync();
+        await Home.LoadAsync();
 
         ClientList.PropertyChanged += (_, e) =>
         {
@@ -22,6 +34,7 @@ public class MainWindowViewModel(
         ClientDetail.Settings.ClientUpdated += async (_, updatedClient) =>
         {
             await ClientList.LoadAsync();
+            await Home.LoadAsync();
             ClientList.SelectedClient = updatedClient;
         };
     }
@@ -29,8 +42,14 @@ public class MainWindowViewModel(
     private void OnSelectedClientChanged(Client? client)
     {
         if (client is null)
+        {
             ClientDetail.Clear();
+            _ = Home.LoadAsync();
+        }
         else
+        {
             ClientDetail.LoadClient(client);
+        }
+        OnPropertyChanged(nameof(ShowHome));
     }
 }

--- a/src/WorkTracking.UI/Views/HomeView.xaml
+++ b/src/WorkTracking.UI/Views/HomeView.xaml
@@ -1,0 +1,256 @@
+<UserControl x:Class="WorkTracking.UI.Views.HomeView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:conv="clr-namespace:WorkTracking.UI.Converters"
+             Background="{StaticResource BackgroundBrush}">
+
+    <UserControl.Resources>
+        <conv:BoolToVisibilityConverter x:Key="BoolToVisibility"/>
+        <conv:InverseBoolToVisibilityConverter x:Key="InverseBoolToVisibility"/>
+    </UserControl.Resources>
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="20,16,20,16">
+        <StackPanel>
+
+            <!-- Loading indicator -->
+            <TextBlock Text="Loading…"
+                       Foreground="{StaticResource TextSecondaryBrush}"
+                       FontSize="13" Margin="0,0,0,12"
+                       Visibility="{Binding IsLoading, Converter={StaticResource BoolToVisibility}}"/>
+
+            <!-- ══════════════════════════════════════════
+                 Summary cards
+            ══════════════════════════════════════════ -->
+            <TextBlock Text="Overview" FontSize="18" FontWeight="Bold"
+                       Foreground="{StaticResource TextPrimaryBrush}" Margin="0,0,0,10"/>
+
+            <UniformGrid Columns="3" Margin="0,0,0,20">
+
+                <!-- Unbilled hours -->
+                <Border Background="{StaticResource SurfaceBrush}"
+                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                        CornerRadius="6" Margin="0,0,8,0" Padding="14,12">
+                    <StackPanel>
+                        <TextBlock Text="Total Unbilled Hours"
+                                   FontSize="11" Foreground="{StaticResource TextSecondaryBrush}"
+                                   Margin="0,0,0,4"/>
+                        <TextBlock Text="{Binding TotalUnbilledHours, StringFormat={}{0:F1} h}"
+                                   FontSize="24" FontWeight="Bold"
+                                   Foreground="{StaticResource AccentBrush}"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Invoiced rolling 30 days -->
+                <Border Background="{StaticResource SurfaceBrush}"
+                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                        CornerRadius="6" Margin="4,0,4,0" Padding="14,12">
+                    <StackPanel>
+                        <TextBlock Text="Invoiced (Last 30 Days)"
+                                   FontSize="11" Foreground="{StaticResource TextSecondaryBrush}"
+                                   Margin="0,0,0,4"/>
+                        <TextBlock Text="{Binding InvoicedRolling30Days, StringFormat=${0:N2}}"
+                                   FontSize="24" FontWeight="Bold"
+                                   Foreground="{StaticResource TextPrimaryBrush}"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Active clients -->
+                <Border Background="{StaticResource SurfaceBrush}"
+                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                        CornerRadius="6" Margin="8,0,0,0" Padding="14,12">
+                    <StackPanel>
+                        <TextBlock Text="Active Clients"
+                                   FontSize="11" Foreground="{StaticResource TextSecondaryBrush}"
+                                   Margin="0,0,0,4"/>
+                        <TextBlock Text="{Binding ActiveClientCount}"
+                                   FontSize="24" FontWeight="Bold"
+                                   Foreground="{StaticResource TextPrimaryBrush}"/>
+                    </StackPanel>
+                </Border>
+
+            </UniformGrid>
+
+            <!-- ══════════════════════════════════════════
+                 Per-client status
+            ══════════════════════════════════════════ -->
+            <TextBlock Text="Client Status" FontSize="15" FontWeight="SemiBold"
+                       Foreground="{StaticResource TextPrimaryBrush}" Margin="0,0,0,8"/>
+
+            <Border Background="{StaticResource SurfaceBrush}"
+                    BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                    CornerRadius="6" Margin="0,0,0,20" Padding="4,0">
+                <ItemsControl ItemsSource="{Binding ClientStatuses}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Grid Margin="10,10,10,10">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="160" MinWidth="100"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="110"/>
+                                </Grid.ColumnDefinitions>
+
+                                <!-- Client name -->
+                                <TextBlock Grid.Column="0"
+                                           Text="{Binding Name}"
+                                           FontWeight="SemiBold"
+                                           VerticalAlignment="Center"
+                                           TextTrimming="CharacterEllipsis"/>
+
+                                <!-- Cap progress bar (only shown when cap is set) -->
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="8,0">
+                                    <ProgressBar Height="6" Minimum="0" Maximum="1"
+                                                 Value="{Binding CapProgress, Mode=OneWay}"
+                                                 Visibility="{Binding HasCap, Converter={StaticResource BoolToVisibility}}"
+                                                 Foreground="{StaticResource AccentBrush}"
+                                                 Background="{StaticResource BorderBrush}"
+                                                 BorderThickness="0"/>
+                                    <TextBlock Text="{Binding UninvoicedHours, Mode=OneWay, StringFormat={}{0:F1} h unbilled}"
+                                               FontSize="11" Foreground="{StaticResource TextSecondaryBrush}"
+                                               Margin="0,2,0,0"
+                                               Visibility="{Binding HasCap, Converter={StaticResource BoolToVisibility}}"/>
+                                    <TextBlock Text="{Binding UninvoicedHours, Mode=OneWay, StringFormat={}{0:F1} h unbilled}"
+                                               FontSize="11" Foreground="{StaticResource TextSecondaryBrush}"
+                                               Visibility="{Binding HasCap, Converter={StaticResource InverseBoolToVisibility}}"/>
+                                </StackPanel>
+
+                                <!-- Over-cap warning -->
+                                <TextBlock Grid.Column="2"
+                                           Text="Over cap"
+                                           Foreground="{StaticResource DangerBrush}"
+                                           FontSize="11" FontWeight="SemiBold"
+                                           VerticalAlignment="Center"
+                                           Margin="4,0"
+                                           Visibility="{Binding IsOverCap, Converter={StaticResource BoolToVisibility}}"/>
+
+                                <!-- Next due label -->
+                                <TextBlock Grid.Column="3"
+                                           Text="{Binding NextDueLabel, Mode=OneWay}"
+                                           FontSize="11" VerticalAlignment="Center"
+                                           HorizontalAlignment="Right">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsOverdue}" Value="True">
+                                                    <Setter Property="Foreground" Value="{StaticResource DangerBrush}"/>
+                                                    <Setter Property="FontWeight" Value="SemiBold"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </Grid>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </Border>
+
+            <!-- ══════════════════════════════════════════
+                 Monthly report (last 12 months)
+            ══════════════════════════════════════════ -->
+            <TextBlock Text="Monthly Report — Last 12 Months" FontSize="15" FontWeight="SemiBold"
+                       Foreground="{StaticResource TextPrimaryBrush}" Margin="0,0,0,8"/>
+
+            <Border Background="{StaticResource SurfaceBrush}"
+                    BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                    CornerRadius="6" Margin="0,0,0,20">
+                <DataGrid ItemsSource="{Binding MonthlyReport}"
+                          AutoGenerateColumns="False"
+                          IsReadOnly="True"
+                          GridLinesVisibility="Horizontal"
+                          HeadersVisibility="Column"
+                          BorderThickness="0"
+                          Background="Transparent"
+                          RowBackground="Transparent"
+                          AlternatingRowBackground="{StaticResource SurfaceAltBrush}"
+                          CanUserResizeRows="False"
+                          CanUserReorderColumns="False">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Month"
+                                            Binding="{Binding Month}"
+                                            Width="120"/>
+                        <DataGridTextColumn Header="Hours"
+                                            Binding="{Binding Hours, StringFormat={}{0:F1}}"
+                                            Width="100"/>
+                        <DataGridTextColumn Header="Invoiced"
+                                            Binding="{Binding InvoicedAmount, StringFormat=${0:N2}}"
+                                            Width="*"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Border>
+
+            <!-- ══════════════════════════════════════════
+                 Cross-client breakdown (two columns)
+            ══════════════════════════════════════════ -->
+            <Grid Margin="0,0,0,4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="16"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Hours by client -->
+                <StackPanel Grid.Column="0">
+                    <TextBlock Text="Hours by Client" FontSize="15" FontWeight="SemiBold"
+                               Foreground="{StaticResource TextPrimaryBrush}" Margin="0,0,0,8"/>
+                    <Border Background="{StaticResource SurfaceBrush}"
+                            BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                            CornerRadius="6">
+                        <DataGrid ItemsSource="{Binding HoursByClient}"
+                                  AutoGenerateColumns="False"
+                                  IsReadOnly="True"
+                                  GridLinesVisibility="Horizontal"
+                                  HeadersVisibility="Column"
+                                  BorderThickness="0"
+                                  Background="Transparent"
+                                  RowBackground="Transparent"
+                                  AlternatingRowBackground="{StaticResource SurfaceAltBrush}"
+                                  CanUserResizeRows="False"
+                                  CanUserReorderColumns="False">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Client"
+                                                    Binding="{Binding ClientName}"
+                                                    Width="*"/>
+                                <DataGridTextColumn Header="Hours"
+                                                    Binding="{Binding Hours, StringFormat={}{0:F1}}"
+                                                    Width="80"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Border>
+                </StackPanel>
+
+                <!-- Hours by category -->
+                <StackPanel Grid.Column="2">
+                    <TextBlock Text="Hours by Category" FontSize="15" FontWeight="SemiBold"
+                               Foreground="{StaticResource TextPrimaryBrush}" Margin="0,0,0,8"/>
+                    <Border Background="{StaticResource SurfaceBrush}"
+                            BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                            CornerRadius="6">
+                        <DataGrid ItemsSource="{Binding CategoryDistribution}"
+                                  AutoGenerateColumns="False"
+                                  IsReadOnly="True"
+                                  GridLinesVisibility="Horizontal"
+                                  HeadersVisibility="Column"
+                                  BorderThickness="0"
+                                  Background="Transparent"
+                                  RowBackground="Transparent"
+                                  AlternatingRowBackground="{StaticResource SurfaceAltBrush}"
+                                  CanUserResizeRows="False"
+                                  CanUserReorderColumns="False">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Category"
+                                                    Binding="{Binding Category}"
+                                                    Width="*"/>
+                                <DataGridTextColumn Header="Hours"
+                                                    Binding="{Binding Hours, StringFormat={}{0:F1}}"
+                                                    Width="80"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Border>
+                </StackPanel>
+            </Grid>
+
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/WorkTracking.UI/Views/HomeView.xaml.cs
+++ b/src/WorkTracking.UI/Views/HomeView.xaml.cs
@@ -1,0 +1,9 @@
+namespace WorkTracking.UI.Views;
+
+public partial class HomeView : System.Windows.Controls.UserControl
+{
+    public HomeView()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/WorkTracking.Tests/UI/HomeViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/HomeViewModelTests.cs
@@ -1,0 +1,213 @@
+using FluentAssertions;
+using Moq;
+using WorkTracking.Core.Models;
+using WorkTracking.Data.Repositories.Interfaces;
+using WorkTracking.UI.ViewModels;
+
+namespace WorkTracking.Tests.UI;
+
+public class HomeViewModelTests
+{
+    private static HomeViewModel MakeVm(
+        List<Client>? clients = null,
+        Dictionary<int, decimal>? uninvoicedHours = null,
+        List<WorkEntry>? allEntries = null,
+        List<Invoice>? allInvoices = null,
+        List<WorkCategory>? categories = null)
+    {
+        clients ??= [];
+        allEntries ??= [];
+        allInvoices ??= [];
+        categories ??= [];
+
+        var clientRepo = new Mock<IClientRepository>();
+        clientRepo.Setup(r => r.GetAllAsync()).ReturnsAsync(clients);
+
+        var entryRepo = new Mock<IWorkEntryRepository>();
+        entryRepo.Setup(r => r.GetUninvoicedHoursByClientAsync())
+                 .ReturnsAsync(uninvoicedHours ?? new Dictionary<int, decimal>());
+        foreach (var client in clients)
+        {
+            var clientId = client.Id;
+            var entries = allEntries.Where(e => e.ClientId == clientId).ToList();
+            entryRepo.Setup(r => r.GetByClientAsync(clientId)).ReturnsAsync(entries);
+        }
+
+        var invoiceRepo = new Mock<IInvoiceRepository>();
+        foreach (var client in clients)
+        {
+            var clientId = client.Id;
+            var invoices = allInvoices.Where(i => i.ClientId == clientId).ToList();
+            invoiceRepo.Setup(r => r.GetByClientAsync(clientId)).ReturnsAsync(invoices);
+        }
+
+        var categoryRepo = new Mock<IWorkCategoryRepository>();
+        categoryRepo.Setup(r => r.GetAllAsync()).ReturnsAsync(categories);
+
+        return new HomeViewModel(clientRepo.Object, entryRepo.Object, invoiceRepo.Object, categoryRepo.Object);
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithNoData_AllZeroes()
+    {
+        var vm = MakeVm();
+
+        await vm.LoadAsync();
+
+        vm.TotalUnbilledHours.Should().Be(0);
+        vm.InvoicedRolling30Days.Should().Be(0);
+        vm.ActiveClientCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ActiveClientCount_ReflectsClientList()
+    {
+        var clients = new List<Client>
+        {
+            new() { Id = 1, Name = "Alpha" },
+            new() { Id = 2, Name = "Beta" }
+        };
+        var vm = MakeVm(clients: clients);
+
+        await vm.LoadAsync();
+
+        vm.ActiveClientCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task LoadAsync_TotalUnbilledHours_SumsAcrossClients()
+    {
+        var clients = new List<Client>
+        {
+            new() { Id = 1, Name = "Alpha" },
+            new() { Id = 2, Name = "Beta" }
+        };
+        var uninvoiced = new Dictionary<int, decimal> { [1] = 3.5m, [2] = 6.0m };
+        var vm = MakeVm(clients: clients, uninvoicedHours: uninvoiced);
+
+        await vm.LoadAsync();
+
+        vm.TotalUnbilledHours.Should().Be(9.5m);
+    }
+
+    [Fact]
+    public async Task LoadAsync_InvoicedRolling30Days_SumsRecentInvoices()
+    {
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var clients = new List<Client> { new() { Id = 1, Name = "Alpha" } };
+        var invoices = new List<Invoice>
+        {
+            new() { Id = 1, ClientId = 1, InvoiceDate = today.AddDays(-5),  TotalAmount = 1000m },
+            new() { Id = 2, ClientId = 1, InvoiceDate = today.AddDays(-15), TotalAmount = 500m  },
+            new() { Id = 3, ClientId = 1, InvoiceDate = today.AddDays(-60), TotalAmount = 999m  } // outside window
+        };
+        var vm = MakeVm(clients: clients, allInvoices: invoices);
+
+        await vm.LoadAsync();
+
+        vm.InvoicedRolling30Days.Should().Be(1500m);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ClientStatuses_OneRowPerClient()
+    {
+        var clients = new List<Client>
+        {
+            new() { Id = 1, Name = "Alpha", HourlyRate = 100m },
+            new() { Id = 2, Name = "Beta",  HourlyRate = 120m }
+        };
+        var vm = MakeVm(clients: clients);
+
+        await vm.LoadAsync();
+
+        vm.ClientStatuses.Should().HaveCount(2);
+        vm.ClientStatuses.Select(s => s.Name).Should().BeEquivalentTo(["Alpha", "Beta"]);
+    }
+
+    [Fact]
+    public async Task LoadAsync_MonthlyReport_HasTwelveEntries()
+    {
+        var vm = MakeVm();
+
+        await vm.LoadAsync();
+
+        vm.MonthlyReport.Should().HaveCount(12);
+    }
+
+    [Fact]
+    public async Task LoadAsync_MonthlyReport_AggregatesHoursCorrectly()
+    {
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var clients = new List<Client> { new() { Id = 1, Name = "Alpha" } };
+        var entries = new List<WorkEntry>
+        {
+            new() { ClientId = 1, Date = today, Hours = 4m },
+            new() { ClientId = 1, Date = today, Hours = 2m }
+        };
+        var vm = MakeVm(clients: clients, allEntries: entries);
+
+        await vm.LoadAsync();
+
+        var thisMonth = vm.MonthlyReport.Last();
+        thisMonth.Hours.Should().Be(6m);
+    }
+
+    [Fact]
+    public async Task LoadAsync_CategoryDistribution_GroupsByCategory()
+    {
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var clients = new List<Client> { new() { Id = 1, Name = "Alpha" } };
+        var categories = new List<WorkCategory>
+        {
+            new() { Id = 10, Name = "Dev" },
+            new() { Id = 20, Name = "Design" }
+        };
+        var entries = new List<WorkEntry>
+        {
+            new() { ClientId = 1, Date = today, Hours = 5m, WorkCategoryId = 10 },
+            new() { ClientId = 1, Date = today, Hours = 3m, WorkCategoryId = 10 },
+            new() { ClientId = 1, Date = today, Hours = 2m, WorkCategoryId = 20 }
+        };
+        var vm = MakeVm(clients: clients, allEntries: entries, categories: categories);
+
+        await vm.LoadAsync();
+
+        vm.CategoryDistribution.Should().HaveCount(2);
+        vm.CategoryDistribution.First(c => c.Category == "Dev").Hours.Should().Be(8m);
+        vm.CategoryDistribution.First(c => c.Category == "Design").Hours.Should().Be(2m);
+    }
+
+    [Fact]
+    public async Task LoadAsync_HoursByClient_SumsAllEntriesPerClient()
+    {
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var clients = new List<Client>
+        {
+            new() { Id = 1, Name = "Alpha" },
+            new() { Id = 2, Name = "Beta"  }
+        };
+        var entries = new List<WorkEntry>
+        {
+            new() { ClientId = 1, Date = today, Hours = 3m },
+            new() { ClientId = 1, Date = today, Hours = 2m },
+            new() { ClientId = 2, Date = today, Hours = 7m }
+        };
+        var vm = MakeVm(clients: clients, allEntries: entries);
+
+        await vm.LoadAsync();
+
+        vm.HoursByClient.Should().HaveCount(2);
+        vm.HoursByClient.First(c => c.ClientName == "Alpha").Hours.Should().Be(5m);
+        vm.HoursByClient.First(c => c.ClientName == "Beta").Hours.Should().Be(7m);
+    }
+
+    [Fact]
+    public async Task LoadAsync_SetsIsLoadingFalseWhenComplete()
+    {
+        var vm = MakeVm();
+
+        await vm.LoadAsync();
+
+        vm.IsLoading.Should().BeFalse();
+    }
+}

--- a/tests/WorkTracking.Tests/UI/MainWindowViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/MainWindowViewModelTests.cs
@@ -60,6 +60,17 @@ public class MainWindowViewModelTests
     }
 
     private static ClientDetailViewModel MakeDetailVm() => new(MakeTimesheetVm(), MakeInvoicesVm(), MakeSummaryVm(), MakeSettingsVm());
+    private static HomeViewModel MakeHomeVm()
+    {
+        var clientRepo = new Mock<IClientRepository>();
+        clientRepo.Setup(r => r.GetAllAsync()).ReturnsAsync([]);
+        var entryRepo = new Mock<IWorkEntryRepository>();
+        entryRepo.Setup(r => r.GetUninvoicedHoursByClientAsync()).ReturnsAsync(new Dictionary<int, decimal>());
+        var invoiceRepo = new Mock<IInvoiceRepository>();
+        var categoryRepo = new Mock<IWorkCategoryRepository>();
+        categoryRepo.Setup(r => r.GetAllAsync()).ReturnsAsync([]);
+        return new HomeViewModel(clientRepo.Object, entryRepo.Object, invoiceRepo.Object, categoryRepo.Object);
+    }
 
     [Fact]
     public async Task InitializeAsync_LoadsClientList()
@@ -67,7 +78,7 @@ public class MainWindowViewModelTests
         var clients = new List<Client> { new() { Id = 1, Name = "Acme" } };
         var listVm = MakeClientListVm(clients);
         var detailVm = MakeDetailVm();
-        var vm = new MainWindowViewModel(listVm, detailVm);
+        var vm = new MainWindowViewModel(listVm, detailVm, MakeHomeVm());
 
         await vm.InitializeAsync();
 
@@ -80,7 +91,7 @@ public class MainWindowViewModelTests
         var client = new Client { Id = 1, Name = "Acme" };
         var listVm = MakeClientListVm([client]);
         var detailVm = MakeDetailVm();
-        var vm = new MainWindowViewModel(listVm, detailVm);
+        var vm = new MainWindowViewModel(listVm, detailVm, MakeHomeVm());
         await vm.InitializeAsync();
 
         listVm.SelectedClient = client;
@@ -95,7 +106,7 @@ public class MainWindowViewModelTests
         var client = new Client { Id = 1, Name = "Acme" };
         var listVm = MakeClientListVm([client]);
         var detailVm = MakeDetailVm();
-        var vm = new MainWindowViewModel(listVm, detailVm);
+        var vm = new MainWindowViewModel(listVm, detailVm, MakeHomeVm());
         await vm.InitializeAsync();
         listVm.SelectedClient = client;
 
@@ -109,7 +120,7 @@ public class MainWindowViewModelTests
     {
         var listVm = MakeClientListVm([]);
         var detailVm = MakeDetailVm();
-        var vm = new MainWindowViewModel(listVm, detailVm);
+        var vm = new MainWindowViewModel(listVm, detailVm, MakeHomeVm());
 
         await vm.InitializeAsync();
 


### PR DESCRIPTION
## Summary

Implements issues #27 and #2 as a combined reporting feature.

## Changes

### New files
- \HomeViewModel\ — aggregates cross-client data: total uninvoiced hours, invoiced (rolling 30 days), active clients, per-client status rows, 12-month rolling report, category distribution, hours-by-client breakdown
- \ClientStatusRowViewModel\ — per-client row for the dashboard status list (cap progress, overdue flag, uninvoiced hours)
- \HomeView.xaml\ / \HomeView.xaml.cs\ — dashboard UI with summary cards, per-client progress bars, monthly DataGrid, and breakdown tables
- \HomeViewModelTests\ — 10 unit tests covering aggregation logic

### Modified files
- \MainWindowViewModel\ — added \Home\ property, \ShowHome\ computed bool, \GoHomeCommand\, \ShowAboutCommand\/event
- \MainWindow.xaml\ — HomeView wrapped in visibility Grid (fixes DataContext+Visibility binding bug), \← Overview\ breadcrumb in client detail header, About button in left panel
- \MainWindow.xaml.cs\ — wires \ShowAboutRequested\ event to open \SplashWindow\ in About mode
- \SplashWindow\ — supports \canClose\ param for reuse as About dialog
- \ServiceCollectionExtensions\ — registers \HomeViewModel\ as Transient
- \MainWindowViewModelTests\ — updated constructors, added \MakeHomeVm()\ helper

## Tests

185/185 passing.