### PR TITLE
feat: dark mode theme switching (#35)

### DIFF
--- a/src/WorkTracking.UI/App.xaml
+++ b/src/WorkTracking.UI/App.xaml
@@ -1,4 +1,4 @@
-﻿<Application x:Class="WorkTracking.UI.App"
+<Application x:Class="WorkTracking.UI.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:converters="clr-namespace:WorkTracking.UI.Converters"
@@ -11,8 +11,8 @@
 
             <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
             <converters:InverseBoolToVisibilityConverter x:Key="InverseBoolToVisibilityConverter"/>
+            <converters:EnumToBoolConverter x:Key="EnumToBoolConverter"/>
 
-            <!-- Implicit TextBlock font only — no Foreground here so buttons/tabs can inherit it -->
             <Style TargetType="TextBlock">
                 <Setter Property="FontFamily" Value="{StaticResource AppFont}"/>
             </Style>

--- a/src/WorkTracking.UI/Converters/EnumToBoolConverter.cs
+++ b/src/WorkTracking.UI/Converters/EnumToBoolConverter.cs
@@ -1,0 +1,17 @@
+using System.Globalization;
+using System.Windows.Data;
+
+namespace WorkTracking.UI.Converters;
+
+public class EnumToBoolConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value?.ToString() == parameter?.ToString();
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is true && parameter is not null)
+            return Enum.Parse(targetType, parameter.ToString()!);
+        return Binding.DoNothing;
+    }
+}

--- a/src/WorkTracking.UI/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/WorkTracking.UI/DependencyInjection/ServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ public static class ServiceCollectionExtensions
         // Services (Singleton)
         services.AddSingleton<IDialogService, DialogService>();
         services.AddSingleton<INavigationService, NavigationService>();
+        services.AddSingleton<IThemeService, ThemeService>();
 
         // ViewModels (Transient)
         services.AddTransient<TimesheetViewModel>();
@@ -36,6 +37,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<ClientListViewModel>();
         services.AddTransient<ClientDetailViewModel>();
         services.AddTransient<HomeViewModel>();
+        services.AddTransient<AppSettingsViewModel>();
         services.AddTransient<MainWindowViewModel>();
 
         // Main window (Singleton — one instance)

--- a/src/WorkTracking.UI/MainWindow.xaml
+++ b/src/WorkTracking.UI/MainWindow.xaml
@@ -7,7 +7,9 @@
         xmlns:views="clr-namespace:WorkTracking.UI.Views"
         mc:Ignorable="d"
         Title="Billable" Height="650" Width="1100"
-        MinHeight="400" MinWidth="700">
+        MinHeight="400" MinWidth="700"
+        Background="{DynamicResource BackgroundBrush}"
+        Foreground="{DynamicResource TextPrimaryBrush}">
 
     <Grid>
         <Grid.ColumnDefinitions>
@@ -17,7 +19,7 @@
         </Grid.ColumnDefinitions>
 
         <!-- Left: client list -->
-        <DockPanel Grid.Column="0" Background="{StaticResource BackgroundBrush}">
+        <DockPanel Grid.Column="0" Background="{DynamicResource BackgroundBrush}">
             <Border DockPanel.Dock="Top" Padding="8,8,8,4">
                 <Grid>
                     <Grid.ColumnDefinitions>
@@ -39,6 +41,12 @@
                     Command="{Binding ShowAboutCommand}"
                     Style="{StaticResource SecondaryButton}"
                     Margin="8,4,8,8" FontSize="11"/>
+            <!-- Settings button above About -->
+            <Button DockPanel.Dock="Bottom"
+                    Content="⚙ Settings"
+                    Command="{Binding GoSettingsCommand}"
+                    Style="{StaticResource SecondaryButton}"
+                    Margin="8,0,8,4" FontSize="11"/>
             <TextBox DockPanel.Dock="Top"
                      Text="{Binding ClientList.SearchText, UpdateSourceTrigger=PropertyChanged}"
                      Margin="8,0,8,6"
@@ -54,13 +62,13 @@
                         <DataTemplate>
                             <StackPanel Margin="4,3">
                                 <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
-                                <TextBlock Text="{Binding CompanyName}" FontSize="11" Foreground="Gray"/>
+                                <TextBlock Text="{Binding CompanyName}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}"/>
                             </StackPanel>
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>
                 <TextBlock Text="No clients yet — click + Add to get started."
-                           Foreground="Gray" FontSize="11" FontStyle="Italic"
+                           Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11" FontStyle="Italic"
                            TextWrapping="Wrap" Margin="10,8"
                            HorizontalAlignment="Center" VerticalAlignment="Top"
                            Visibility="{Binding ClientList.HasClients,
@@ -71,18 +79,23 @@
         <!-- Splitter -->
         <GridSplitter Grid.Column="1" Width="4"
                       HorizontalAlignment="Stretch"
-                      Background="{StaticResource BorderBrush}"/>
+                      Background="{DynamicResource BorderBrush}"/>
 
-        <!-- Right: client detail or home dashboard -->
-        <Grid Grid.Column="2">
-            <!-- Home dashboard (no client selected) -->
+        <!-- Right: client detail, home dashboard, or app settings -->
+        <Grid Grid.Column="2" Background="{DynamicResource BackgroundBrush}">
+            <!-- Home dashboard (no client selected, settings not active) -->
             <Grid Visibility="{Binding ShowHome, Converter={StaticResource BoolToVisibilityConverter}}">
                 <views:HomeView DataContext="{Binding Home}"/>
             </Grid>
 
+            <!-- App settings panel -->
+            <Grid Visibility="{Binding ShowSettings, Converter={StaticResource BoolToVisibilityConverter}}">
+                <views:AppSettingsView DataContext="{Binding AppSettings}"/>
+            </Grid>
+
             <!-- Client detail tabs -->
-            <DockPanel Visibility="{Binding ShowHome,
-                           Converter={StaticResource InverseBoolToVisibilityConverter}}">
+            <DockPanel Visibility="{Binding ShowClientDetail, Converter={StaticResource BoolToVisibilityConverter}}"
+                       x:Name="ClientDetailPanel">
                 <Grid DockPanel.Dock="Top" Margin="16,10,16,6">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -102,7 +115,7 @@
                             Padding="0,0" FontSize="11"
                             BorderThickness="0"
                             Background="Transparent"
-                            Foreground="{StaticResource TextSecondaryBrush}"
+                            Foreground="{DynamicResource TextSecondaryBrush}"
                             Margin="0,0,0,2"/>
 
                     <!-- Client name -->

--- a/src/WorkTracking.UI/Services/IThemeService.cs
+++ b/src/WorkTracking.UI/Services/IThemeService.cs
@@ -1,0 +1,13 @@
+namespace WorkTracking.UI.Services;
+
+public interface IThemeService
+{
+    AppTheme CurrentTheme { get; }
+    void Apply(AppTheme theme);
+}
+
+public enum AppTheme
+{
+    Light,
+    Dark
+}

--- a/src/WorkTracking.UI/Services/ThemeService.cs
+++ b/src/WorkTracking.UI/Services/ThemeService.cs
@@ -1,0 +1,67 @@
+using System.Windows;
+using System.Windows.Media;
+
+namespace WorkTracking.UI.Services;
+
+public class ThemeService : IThemeService
+{
+    // Brush keys must match exactly the x:Key values in ModernTheme.xaml.
+    private static readonly IReadOnlyDictionary<string, Color> LightColours =
+        new Dictionary<string, Color>
+        {
+            ["AccentBrush"]            = Color.FromArgb(0xFF, 0x00, 0x67, 0xC0),
+            ["AccentHoverBrush"]       = Color.FromArgb(0xFF, 0x00, 0x5A, 0xA3),
+            ["AccentPressedBrush"]     = Color.FromArgb(0xFF, 0x00, 0x4D, 0x8C),
+            ["AccentDisabledBrush"]    = Color.FromArgb(0xFF, 0xA8, 0xC8, 0xEB),
+            ["BackgroundBrush"]        = Color.FromArgb(0xFF, 0xF3, 0xF3, 0xF3),
+            ["SurfaceBrush"]           = Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF),
+            ["SurfaceAltBrush"]        = Color.FromArgb(0xFF, 0xFA, 0xFA, 0xFA),
+            ["BorderBrush"]            = Color.FromArgb(0xFF, 0xE0, 0xE0, 0xE0),
+            ["TextPrimaryBrush"]       = Color.FromArgb(0xFF, 0x1A, 0x1A, 0x1A),
+            ["TextSecondaryBrush"]     = Color.FromArgb(0xFF, 0x6E, 0x6E, 0x6E),
+            ["DangerBrush"]            = Color.FromArgb(0xFF, 0xC4, 0x2B, 0x1C),
+            ["DangerHoverBrush"]       = Color.FromArgb(0xFF, 0xFD, 0xEC, 0xEC),
+            ["HoverBrush"]             = Color.FromArgb(0xFF, 0xE8, 0xE8, 0xE8),
+            ["SecondaryHoverBrush"]    = Color.FromArgb(0xFF, 0xEF, 0xF0, 0xF1),
+            ["ListSelectedBrush"]      = Color.FromArgb(0xFF, 0xD0, 0xE6, 0xF8),
+            ["ListSelectedHoverBrush"] = Color.FromArgb(0xFF, 0xBC, 0xDB, 0xF5),
+            ["DataGridAltRowBrush"]    = Color.FromArgb(0xFF, 0xF8, 0xF8, 0xF8),
+        };
+
+    private static readonly IReadOnlyDictionary<string, Color> DarkColours =
+        new Dictionary<string, Color>
+        {
+            ["AccentBrush"]            = Color.FromArgb(0xFF, 0x4F, 0xA3, 0xE3),
+            ["AccentHoverBrush"]       = Color.FromArgb(0xFF, 0x3D, 0x8F, 0xCC),
+            ["AccentPressedBrush"]     = Color.FromArgb(0xFF, 0x2D, 0x7A, 0xB5),
+            ["AccentDisabledBrush"]    = Color.FromArgb(0xFF, 0x3A, 0x5A, 0x78),
+            ["BackgroundBrush"]        = Color.FromArgb(0xFF, 0x1E, 0x1E, 0x1E),
+            ["SurfaceBrush"]           = Color.FromArgb(0xFF, 0x25, 0x25, 0x26),
+            ["SurfaceAltBrush"]        = Color.FromArgb(0xFF, 0x2D, 0x2D, 0x30),
+            ["BorderBrush"]            = Color.FromArgb(0xFF, 0x3F, 0x3F, 0x46),
+            ["TextPrimaryBrush"]       = Color.FromArgb(0xFF, 0xE8, 0xE8, 0xE8),
+            ["TextSecondaryBrush"]     = Color.FromArgb(0xFF, 0x9D, 0x9D, 0x9D),
+            ["DangerBrush"]            = Color.FromArgb(0xFF, 0xFF, 0x6B, 0x6B),
+            ["DangerHoverBrush"]       = Color.FromArgb(0xFF, 0x3D, 0x1A, 0x1A),
+            ["HoverBrush"]             = Color.FromArgb(0xFF, 0x3E, 0x3E, 0x42),
+            ["SecondaryHoverBrush"]    = Color.FromArgb(0xFF, 0x2F, 0x2F, 0x33),
+            ["ListSelectedBrush"]      = Color.FromArgb(0xFF, 0x1C, 0x3A, 0x52),
+            ["ListSelectedHoverBrush"] = Color.FromArgb(0xFF, 0x1A, 0x48, 0x70),
+            ["DataGridAltRowBrush"]    = Color.FromArgb(0xFF, 0x2A, 0x2A, 0x2E),
+        };
+
+    public AppTheme CurrentTheme { get; private set; } = AppTheme.Light;
+
+    public void Apply(AppTheme theme)
+    {
+        CurrentTheme = theme;
+        var colours = theme == AppTheme.Dark ? DarkColours : LightColours;
+        var resources = Application.Current.Resources;
+
+        foreach (var (key, color) in colours)
+        {
+            if (resources[key] is SolidColorBrush)
+                resources[key] = new SolidColorBrush(color);
+        }
+    }
+}

--- a/src/WorkTracking.UI/Themes/ModernTheme.xaml
+++ b/src/WorkTracking.UI/Themes/ModernTheme.xaml
@@ -1,9 +1,9 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <!-- â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
-         COLOURS
-    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• -->
+    <!-- ═══════════════════════════════════════════════════════════════
+         COLOURS  (light defaults — ThemeService mutates these at runtime)
+    ═══════════════════════════════════════════════════════════════ -->
     <Color x:Key="ColorAccent">#FF0067C0</Color>
     <Color x:Key="ColorAccentHover">#FF005AA3</Color>
     <Color x:Key="ColorAccentPressed">#FF004D8C</Color>
@@ -18,58 +18,59 @@
     <Color x:Key="ColorDangerHover">#FFFDECEC</Color>
     <Color x:Key="ColorHover">#FFE8E8E8</Color>
     <Color x:Key="ColorSecondaryHover">#FFEFF0F1</Color>
+    <Color x:Key="ColorListSelected">#FFD0E6F8</Color>
+    <Color x:Key="ColorListSelectedHover">#FFBCDBF5</Color>
+    <Color x:Key="ColorDataGridAltRow">#FFF8F8F8</Color>
 
-    <!-- â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
+    <!-- ═══════════════════════════════════════════════════════════════
          BRUSHES
-    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• -->
-    <SolidColorBrush x:Key="AccentBrush"          Color="{StaticResource ColorAccent}"/>
-    <SolidColorBrush x:Key="AccentHoverBrush"     Color="{StaticResource ColorAccentHover}"/>
-    <SolidColorBrush x:Key="AccentPressedBrush"   Color="{StaticResource ColorAccentPressed}"/>
-    <SolidColorBrush x:Key="AccentDisabledBrush"  Color="{StaticResource ColorAccentDisabled}"/>
-    <SolidColorBrush x:Key="BackgroundBrush"      Color="{StaticResource ColorBackground}"/>
-    <SolidColorBrush x:Key="SurfaceBrush"         Color="{StaticResource ColorSurface}"/>
-    <SolidColorBrush x:Key="SurfaceAltBrush"      Color="{StaticResource ColorSurfaceAlt}"/>
-    <SolidColorBrush x:Key="BorderBrush"          Color="{StaticResource ColorBorder}"/>
-    <SolidColorBrush x:Key="TextPrimaryBrush"     Color="{StaticResource ColorTextPrimary}"/>
-    <SolidColorBrush x:Key="TextSecondaryBrush"   Color="{StaticResource ColorTextSecondary}"/>
-    <SolidColorBrush x:Key="DangerBrush"          Color="{StaticResource ColorDanger}"/>
-    <SolidColorBrush x:Key="DangerHoverBrush"     Color="{StaticResource ColorDangerHover}"/>
-    <SolidColorBrush x:Key="HoverBrush"           Color="{StaticResource ColorHover}"/>
-    <SolidColorBrush x:Key="SecondaryHoverBrush"  Color="{StaticResource ColorSecondaryHover}"/>
-    <SolidColorBrush x:Key="TransparentBrush"     Color="Transparent"/>
+    ═══════════════════════════════════════════════════════════════ -->
+    <SolidColorBrush x:Key="AccentBrush"            Color="{StaticResource ColorAccent}"/>
+    <SolidColorBrush x:Key="AccentHoverBrush"       Color="{StaticResource ColorAccentHover}"/>
+    <SolidColorBrush x:Key="AccentPressedBrush"     Color="{StaticResource ColorAccentPressed}"/>
+    <SolidColorBrush x:Key="AccentDisabledBrush"    Color="{StaticResource ColorAccentDisabled}"/>
+    <SolidColorBrush x:Key="BackgroundBrush"        Color="{StaticResource ColorBackground}"/>
+    <SolidColorBrush x:Key="SurfaceBrush"           Color="{StaticResource ColorSurface}"/>
+    <SolidColorBrush x:Key="SurfaceAltBrush"        Color="{StaticResource ColorSurfaceAlt}"/>
+    <SolidColorBrush x:Key="BorderBrush"            Color="{StaticResource ColorBorder}"/>
+    <SolidColorBrush x:Key="TextPrimaryBrush"       Color="{StaticResource ColorTextPrimary}"/>
+    <SolidColorBrush x:Key="TextSecondaryBrush"     Color="{StaticResource ColorTextSecondary}"/>
+    <SolidColorBrush x:Key="DangerBrush"            Color="{StaticResource ColorDanger}"/>
+    <SolidColorBrush x:Key="DangerHoverBrush"       Color="{StaticResource ColorDangerHover}"/>
+    <SolidColorBrush x:Key="HoverBrush"             Color="{StaticResource ColorHover}"/>
+    <SolidColorBrush x:Key="SecondaryHoverBrush"    Color="{StaticResource ColorSecondaryHover}"/>
+    <SolidColorBrush x:Key="TransparentBrush"       Color="Transparent"/>
+    <SolidColorBrush x:Key="ListSelectedBrush"      Color="{StaticResource ColorListSelected}"/>
+    <SolidColorBrush x:Key="ListSelectedHoverBrush" Color="{StaticResource ColorListSelectedHover}"/>
+    <SolidColorBrush x:Key="DataGridAltRowBrush"    Color="{StaticResource ColorDataGridAltRow}"/>
 
-    <!-- â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
+    <!-- ═══════════════════════════════════════════════════════════════
          TYPOGRAPHY
-    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• -->
+    ═══════════════════════════════════════════════════════════════ -->
     <FontFamily x:Key="AppFont">Segoe UI Variable, Segoe UI, sans-serif</FontFamily>
 
-    <!-- â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
-         ICON GEOMETRY (Octicons 16Ã—16)
-    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• -->
-    <!-- Plus / Add -->
+    <!-- ═══════════════════════════════════════════════════════════════
+         ICON GEOMETRY (Octicons 16x16)
+    ═══════════════════════════════════════════════════════════════ -->
     <Geometry x:Key="IconAdd">M7.75 2a.75.75 0 0 1 .75.75V7h4.25a.75.75 0 0 1 0 1.5H8.5v4.25a.75.75 0 0 1-1.5 0V8.5H2.75a.75.75 0 0 1 0-1.5H7V2.75A.75.75 0 0 1 7.75 2Z</Geometry>
-    <!-- Pencil / Edit -->
     <Geometry x:Key="IconEdit">M11.013 1.427a1.75 1.75 0 0 1 2.474 0l1.086 1.086a1.75 1.75 0 0 1 0 2.474L4.625 14.922a2.25 2.25 0 0 1-1.591.659H1.75a.75.75 0 0 1-.75-.75v-2.285a2.25 2.25 0 0 1 .659-1.59L11.013 1.428Zm1.414 1.06a.25.25 0 0 0-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 0 0 0-.354l-1.086-1.086ZM11.189 6.25 9.75 4.81 3.428 11.13a.75.75 0 0 0-.22.53v1.64h1.64a.75.75 0 0 0 .53-.22L11.19 6.25Z</Geometry>
-    <!-- Trash / Delete -->
     <Geometry x:Key="IconDelete">M11 1.75V3h2.25a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1 0-1.5H5V1.75C5 .784 5.784 0 6.75 0h2.5C10.216 0 11 .784 11 1.75ZM4.496 6.675l.595 7.18a.25.25 0 0 0 .249.225h5.32a.25.25 0 0 0 .249-.225l.595-7.18a.75.75 0 0 1 1.492.15l-.595 7.18A1.75 1.75 0 0 1 10.66 16H5.34a1.75 1.75 0 0 1-1.741-1.595l-.595-7.18a.75.75 0 0 1 1.492-.15Z</Geometry>
-    <!-- Eye / View -->
     <Geometry x:Key="IconView">M8 2c1.981 0 3.671.992 4.933 2.078 1.27 1.091 2.187 2.345 2.637 3.023a1.62 1.62 0 0 1 0 1.798c-.45.678-1.367 1.932-2.637 3.023C11.67 13.008 9.981 14 8 14c-1.981 0-3.671-.992-4.933-2.078C1.797 10.83.88 9.576.43 8.898a1.62 1.62 0 0 1 0-1.798c.45-.677 1.367-1.931 2.637-3.022C4.33 2.992 6.019 2 8 2ZM1.679 7.932a.12.12 0 0 0 0 .136c.411.622 1.241 1.75 2.366 2.717C5.176 11.758 6.527 12.5 8 12.5c1.473 0 2.824-.742 3.955-1.715 1.125-.967 1.955-2.095 2.366-2.717a.12.12 0 0 0 0-.136c-.411-.622-1.241-1.75-2.366-2.717C10.824 4.242 9.473 3.5 8 3.5c-1.473 0-2.824.742-3.955 1.715-1.125.967-1.955 2.095-2.366 2.717ZM8 10a2 2 0 1 1-.001-3.999A2 2 0 0 1 8 10Z</Geometry>
-    <!-- File / Notes -->
     <Geometry x:Key="IconNotes">M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16H3.75A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 8.75 4.25V1.5Zm6.75.56v2.19c0 .138.112.25.25.25h2.19Z</Geometry>
 
-    <!-- â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
-         SHARED TEMPLATES
-    â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• -->
+    <!-- ═══════════════════════════════════════════════════════════════
+         BUTTON STYLES
+    ═══════════════════════════════════════════════════════════════ -->
 
-    <!-- â”€â”€â”€ PrimaryButton â”€â”€â”€ -->
+    <!-- PrimaryButton -->
     <Style x:Key="PrimaryButton" TargetType="Button">
-        <Setter Property="Background"   Value="{StaticResource AccentBrush}"/>
-        <Setter Property="Foreground"   Value="White"/>
+        <Setter Property="Background"      Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="Foreground"      Value="White"/>
         <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="Padding"      Value="16,6"/>
-        <Setter Property="FontSize"     Value="13"/>
-        <Setter Property="FontFamily"   Value="{StaticResource AppFont}"/>
-        <Setter Property="Cursor"       Value="Hand"/>
+        <Setter Property="Padding"         Value="16,6"/>
+        <Setter Property="FontSize"        Value="13"/>
+        <Setter Property="FontFamily"      Value="{StaticResource AppFont}"/>
+        <Setter Property="Cursor"          Value="Hand"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -80,17 +81,18 @@
                             Padding="{TemplateBinding Padding}">
                         <ContentPresenter HorizontalAlignment="Center"
                                           VerticalAlignment="Center"
-                                          RecognizesAccessKey="True"/>
+                                          RecognizesAccessKey="True"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"/>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource AccentHoverBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource AccentHoverBrush}"/>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource AccentPressedBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource AccentPressedBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource AccentDisabledBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource AccentDisabledBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -98,11 +100,11 @@
         </Setter>
     </Style>
 
-    <!-- â”€â”€â”€ SecondaryButton â”€â”€â”€ -->
+    <!-- SecondaryButton -->
     <Style x:Key="SecondaryButton" TargetType="Button">
         <Setter Property="Background"      Value="Transparent"/>
-        <Setter Property="Foreground"      Value="{StaticResource TextPrimaryBrush}"/>
-        <Setter Property="BorderBrush"     Value="{StaticResource BorderBrush}"/>
+        <Setter Property="Foreground"      Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource BorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Padding"         Value="16,6"/>
         <Setter Property="FontSize"        Value="13"/>
@@ -120,14 +122,15 @@
                             Padding="{TemplateBinding Padding}">
                         <ContentPresenter HorizontalAlignment="Center"
                                           VerticalAlignment="Center"
-                                          RecognizesAccessKey="True"/>
+                                          RecognizesAccessKey="True"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"/>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource SecondaryHoverBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource SecondaryHoverBrush}"/>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource HoverBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource HoverBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.5"/>
@@ -138,17 +141,17 @@
         </Setter>
     </Style>
 
-    <!-- â”€â”€â”€ ToolbarButton (SecondaryButton, smaller padding) â”€â”€â”€ -->
+    <!-- ToolbarButton -->
     <Style x:Key="ToolbarButton" TargetType="Button" BasedOn="{StaticResource SecondaryButton}">
-        <Setter Property="Padding"   Value="8,4"/>
-        <Setter Property="FontSize"  Value="12"/>
+        <Setter Property="Padding"  Value="8,4"/>
+        <Setter Property="FontSize" Value="12"/>
     </Style>
 
-    <!-- â”€â”€â”€ DangerButton â”€â”€â”€ -->
+    <!-- DangerButton -->
     <Style x:Key="DangerButton" TargetType="Button">
         <Setter Property="Background"      Value="Transparent"/>
-        <Setter Property="Foreground"      Value="{StaticResource DangerBrush}"/>
-        <Setter Property="BorderBrush"     Value="{StaticResource DangerBrush}"/>
+        <Setter Property="Foreground"      Value="{DynamicResource DangerBrush}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource DangerBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Padding"         Value="12,5"/>
         <Setter Property="FontSize"        Value="12"/>
@@ -171,10 +174,10 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource DangerHoverBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource DangerHoverBrush}"/>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="#FFF5C5C5"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource DangerHoverBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.5"/>
@@ -185,11 +188,11 @@
         </Setter>
     </Style>
 
-    <!-- â”€â”€â”€ ToolbarToggleButton â”€â”€â”€ -->
+    <!-- ToolbarToggleButton -->
     <Style x:Key="ToolbarToggleButton" TargetType="ToggleButton">
         <Setter Property="Background"      Value="Transparent"/>
-        <Setter Property="Foreground"      Value="{StaticResource TextPrimaryBrush}"/>
-        <Setter Property="BorderBrush"     Value="{StaticResource BorderBrush}"/>
+        <Setter Property="Foreground"      Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource BorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Padding"         Value="8,4"/>
         <Setter Property="FontSize"        Value="12"/>
@@ -206,26 +209,27 @@
                             CornerRadius="4"
                             Padding="{TemplateBinding Padding}">
                         <ContentPresenter HorizontalAlignment="Center"
-                                          VerticalAlignment="Center"/>
+                                          VerticalAlignment="Center"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"/>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource AccentBrush}"/>
-                            <Setter TargetName="bd" Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource AccentBrush}"/>
+                            <Setter TargetName="bd" Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
                             <Setter Property="Foreground" Value="White"/>
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource SecondaryHoverBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource SecondaryHoverBrush}"/>
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsChecked"    Value="True"/>
-                                <Condition Property="IsMouseOver"  Value="True"/>
+                                <Condition Property="IsChecked"   Value="True"/>
+                                <Condition Property="IsMouseOver" Value="True"/>
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource AccentHoverBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource AccentHoverBrush}"/>
                         </MultiTrigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource HoverBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource HoverBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -233,16 +237,18 @@
         </Setter>
     </Style>
 
-    <!-- â”€â”€â”€ TextBox default override â”€â”€â”€ -->
+    <!-- ═══════════════════════════════════════════════════════════════
+         TEXT BOX
+    ═══════════════════════════════════════════════════════════════ -->
     <Style TargetType="TextBox">
-        <Setter Property="FontFamily"        Value="{StaticResource AppFont}"/>
-        <Setter Property="FontSize"          Value="13"/>
-        <Setter Property="Foreground"        Value="{StaticResource TextPrimaryBrush}"/>
-        <Setter Property="Background"        Value="{StaticResource SurfaceBrush}"/>
-        <Setter Property="BorderBrush"       Value="{StaticResource BorderBrush}"/>
-        <Setter Property="BorderThickness"   Value="1"/>
-        <Setter Property="Padding"           Value="6,4"/>
-        <Setter Property="SelectionBrush"    Value="{StaticResource AccentBrush}"/>
+        <Setter Property="FontFamily"      Value="{StaticResource AppFont}"/>
+        <Setter Property="FontSize"        Value="13"/>
+        <Setter Property="Foreground"      Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="Background"      Value="{DynamicResource SurfaceBrush}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource BorderBrush}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Padding"         Value="6,4"/>
+        <Setter Property="SelectionBrush"  Value="{DynamicResource AccentBrush}"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -261,14 +267,14 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsFocused" Value="True">
-                            <Setter TargetName="bd" Property="BorderBrush" Value="{StaticResource AccentBrush}"/>
+                            <Setter TargetName="bd" Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
                             <Setter TargetName="bd" Property="BorderThickness" Value="1.5"/>
                         </Trigger>
                         <Trigger Property="IsReadOnly" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource BackgroundBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource BackgroundBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource BackgroundBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource BackgroundBrush}"/>
                             <Setter Property="Opacity" Value="0.6"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -277,47 +283,46 @@
         </Setter>
     </Style>
 
-    <!-- â”€â”€â”€ SectionHeader â”€â”€â”€ -->
+    <!-- ═══════════════════════════════════════════════════════════════
+         NAMED STYLES
+    ═══════════════════════════════════════════════════════════════ -->
     <Style x:Key="SectionHeader" TargetType="TextBlock">
-        <Setter Property="FontFamily"  Value="{StaticResource AppFont}"/>
-        <Setter Property="FontSize"    Value="14"/>
-        <Setter Property="FontWeight"  Value="SemiBold"/>
-        <Setter Property="Foreground"  Value="{StaticResource TextPrimaryBrush}"/>
+        <Setter Property="FontFamily" Value="{StaticResource AppFont}"/>
+        <Setter Property="FontSize"   Value="14"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
     </Style>
 
-    <!-- â”€â”€â”€ Card (raised surface) â”€â”€â”€ -->
     <Style x:Key="Card" TargetType="Border">
-        <Setter Property="Background"      Value="{StaticResource SurfaceBrush}"/>
-        <Setter Property="BorderBrush"     Value="{StaticResource BorderBrush}"/>
+        <Setter Property="Background"      Value="{DynamicResource SurfaceBrush}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource BorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="CornerRadius"    Value="6"/>
         <Setter Property="Padding"         Value="16"/>
     </Style>
 
-    <!-- â”€â”€â”€ ToolbarPanel (top toolbar strip) â”€â”€â”€ -->
     <Style x:Key="ToolbarPanel" TargetType="Border">
-        <Setter Property="Background"      Value="{StaticResource SurfaceAltBrush}"/>
-        <Setter Property="BorderBrush"     Value="{StaticResource BorderBrush}"/>
+        <Setter Property="Background"      Value="{DynamicResource SurfaceAltBrush}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource BorderBrush}"/>
         <Setter Property="BorderThickness" Value="0,0,0,1"/>
         <Setter Property="Padding"         Value="8,6"/>
     </Style>
-
 
     <!-- ═══════════════════════════════════════════════════════════════
          WINDOW
     ═══════════════════════════════════════════════════════════════ -->
     <Style TargetType="Window">
-        <Setter Property="Background"  Value="{StaticResource BackgroundBrush}"/>
-        <Setter Property="Foreground"  Value="{StaticResource TextPrimaryBrush}"/>
-        <Setter Property="FontFamily"  Value="{StaticResource AppFont}"/>
-        <Setter Property="FontSize"    Value="13"/>
+        <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="FontFamily" Value="{StaticResource AppFont}"/>
+        <Setter Property="FontSize"   Value="13"/>
     </Style>
 
     <!-- ═══════════════════════════════════════════════════════════════
-         TAB CONTROL / TAB ITEM  (flat, underline-indicator)
+         TAB CONTROL / TAB ITEM
     ═══════════════════════════════════════════════════════════════ -->
     <Style TargetType="TabControl">
-        <Setter Property="Background"      Value="{StaticResource SurfaceBrush}"/>
+        <Setter Property="Background"      Value="{DynamicResource SurfaceBrush}"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Padding"         Value="0"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
@@ -326,7 +331,7 @@
                 <ControlTemplate TargetType="TabControl">
                     <DockPanel>
                         <Border DockPanel.Dock="Top"
-                                BorderBrush="{StaticResource BorderBrush}"
+                                BorderBrush="{DynamicResource BorderBrush}"
                                 BorderThickness="0,0,0,1"
                                 Background="Transparent">
                             <TabPanel IsItemsHost="True" Background="Transparent"/>
@@ -341,12 +346,12 @@
     </Style>
 
     <Style TargetType="TabItem">
-        <Setter Property="FontFamily"  Value="{StaticResource AppFont}"/>
-        <Setter Property="FontSize"    Value="13"/>
-        <Setter Property="Foreground"  Value="{StaticResource TextSecondaryBrush}"/>
-        <Setter Property="Background"  Value="Transparent"/>
-        <Setter Property="Padding"     Value="16,8,16,7"/>
-        <Setter Property="Margin"      Value="0"/>
+        <Setter Property="FontFamily" Value="{StaticResource AppFont}"/>
+        <Setter Property="FontSize"   Value="13"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Padding"    Value="16,8,16,7"/>
+        <Setter Property="Margin"     Value="0"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -356,9 +361,9 @@
                                 Background="{TemplateBinding Background}"
                                 Padding="{TemplateBinding Padding}">
                             <ContentPresenter ContentSource="Header"
-                                             HorizontalAlignment="Center"
-                                             VerticalAlignment="Center"
-                                             TextElement.Foreground="{TemplateBinding Foreground}"/>
+                                              HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              TextElement.Foreground="{TemplateBinding Foreground}"/>
                         </Border>
                         <Border x:Name="indicator"
                                 Height="2" Background="Transparent"
@@ -366,11 +371,11 @@
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsSelected" Value="True">
-                            <Setter Property="Foreground"  Value="{StaticResource AccentBrush}"/>
-                            <Setter TargetName="indicator" Property="Background" Value="{StaticResource AccentBrush}"/>
+                            <Setter Property="Foreground"  Value="{DynamicResource AccentBrush}"/>
+                            <Setter TargetName="indicator" Property="Background" Value="{DynamicResource AccentBrush}"/>
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="bg" Property="Background" Value="{StaticResource SecondaryHoverBrush}"/>
+                            <Setter TargetName="bg" Property="Background" Value="{DynamicResource SecondaryHoverBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -390,12 +395,12 @@
     </Style>
 
     <Style TargetType="ListBoxItem">
-        <Setter Property="Background"                Value="Transparent"/>
-        <Setter Property="Foreground"                Value="{StaticResource TextPrimaryBrush}"/>
-        <Setter Property="Padding"                   Value="0"/>
-        <Setter Property="Margin"                    Value="0,1"/>
+        <Setter Property="Background"                 Value="Transparent"/>
+        <Setter Property="Foreground"                 Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="Padding"                    Value="0"/>
+        <Setter Property="Margin"                     Value="0,1"/>
         <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-        <Setter Property="SnapsToDevicePixels"       Value="True"/>
+        <Setter Property="SnapsToDevicePixels"        Value="True"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ListBoxItem">
@@ -409,18 +414,18 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="{StaticResource SecondaryHoverBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource SecondaryHoverBrush}"/>
                         </Trigger>
                         <Trigger Property="IsSelected" Value="True">
-                            <Setter TargetName="bd" Property="Background" Value="#FFD0E6F8"/>
-                            <Setter Property="Foreground" Value="{StaticResource AccentBrush}"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource ListSelectedBrush}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsSelected"   Value="True"/>
-                                <Condition Property="IsMouseOver"  Value="True"/>
+                                <Condition Property="IsSelected"  Value="True"/>
+                                <Condition Property="IsMouseOver" Value="True"/>
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="bd" Property="Background" Value="#FFBCDBF5"/>
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource ListSelectedHoverBrush}"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -432,61 +437,61 @@
          DATA GRID
     ═══════════════════════════════════════════════════════════════ -->
     <Style TargetType="DataGrid">
-        <Setter Property="Background"             Value="{StaticResource SurfaceBrush}"/>
-        <Setter Property="RowBackground"          Value="{StaticResource SurfaceBrush}"/>
-        <Setter Property="AlternatingRowBackground" Value="#FFF8F8F8"/>
-        <Setter Property="BorderBrush"            Value="{StaticResource BorderBrush}"/>
-        <Setter Property="HorizontalGridLinesBrush" Value="{StaticResource BorderBrush}"/>
+        <Setter Property="Background"               Value="{DynamicResource SurfaceBrush}"/>
+        <Setter Property="RowBackground"            Value="{DynamicResource SurfaceBrush}"/>
+        <Setter Property="AlternatingRowBackground" Value="{DynamicResource DataGridAltRowBrush}"/>
+        <Setter Property="BorderBrush"              Value="{DynamicResource BorderBrush}"/>
+        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource BorderBrush}"/>
         <Setter Property="VerticalGridLinesBrush"   Value="Transparent"/>
-        <Setter Property="GridLinesVisibility"    Value="Horizontal"/>
-        <Setter Property="FontFamily"             Value="{StaticResource AppFont}"/>
-        <Setter Property="FontSize"               Value="13"/>
-        <Setter Property="Foreground"             Value="{StaticResource TextPrimaryBrush}"/>
-        <Setter Property="SelectionMode"          Value="Single"/>
-        <Setter Property="RowHeaderWidth"         Value="0"/>
+        <Setter Property="GridLinesVisibility"      Value="Horizontal"/>
+        <Setter Property="FontFamily"               Value="{StaticResource AppFont}"/>
+        <Setter Property="FontSize"                 Value="13"/>
+        <Setter Property="Foreground"               Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="SelectionMode"            Value="Single"/>
+        <Setter Property="RowHeaderWidth"           Value="0"/>
     </Style>
 
     <Style TargetType="DataGridColumnHeader">
-        <Setter Property="Background"      Value="{StaticResource BackgroundBrush}"/>
-        <Setter Property="Foreground"      Value="{StaticResource TextSecondaryBrush}"/>
+        <Setter Property="Background"      Value="{DynamicResource BackgroundBrush}"/>
+        <Setter Property="Foreground"      Value="{DynamicResource TextSecondaryBrush}"/>
         <Setter Property="FontSize"        Value="11"/>
         <Setter Property="FontWeight"      Value="SemiBold"/>
         <Setter Property="Padding"         Value="8,6"/>
-        <Setter Property="BorderBrush"     Value="{StaticResource BorderBrush}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource BorderBrush}"/>
         <Setter Property="BorderThickness" Value="0,0,0,1"/>
-        <Setter Property="SeparatorBrush"  Value="{StaticResource BorderBrush}"/>
+        <Setter Property="SeparatorBrush"  Value="{DynamicResource BorderBrush}"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
     </Style>
 
     <Style TargetType="DataGridRow">
-        <Setter Property="Foreground"  Value="{StaticResource TextPrimaryBrush}"/>
+        <Setter Property="Foreground"  Value="{DynamicResource TextPrimaryBrush}"/>
         <Setter Property="FontFamily"  Value="{StaticResource AppFont}"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Background" Value="{StaticResource SecondaryHoverBrush}"/>
+                <Setter Property="Background" Value="{DynamicResource SecondaryHoverBrush}"/>
             </Trigger>
             <Trigger Property="IsSelected" Value="True">
-                <Setter Property="Background" Value="#FFD0E6F8"/>
+                <Setter Property="Background" Value="{DynamicResource ListSelectedBrush}"/>
             </Trigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
                     <Condition Property="IsSelected"  Value="True"/>
                     <Condition Property="IsMouseOver" Value="True"/>
                 </MultiTrigger.Conditions>
-                <Setter Property="Background" Value="#FFBCDBF5"/>
+                <Setter Property="Background" Value="{DynamicResource ListSelectedHoverBrush}"/>
             </MultiTrigger>
         </Style.Triggers>
     </Style>
 
     <Style TargetType="DataGridCell">
-        <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="Padding"         Value="0"/>
+        <Setter Property="BorderThickness"  Value="0"/>
+        <Setter Property="Padding"          Value="0"/>
         <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
         <Style.Triggers>
             <Trigger Property="IsSelected" Value="True">
-                <Setter Property="Background" Value="Transparent"/>
-                <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
+                <Setter Property="Background"  Value="Transparent"/>
+                <Setter Property="Foreground"  Value="{DynamicResource TextPrimaryBrush}"/>
                 <Setter Property="BorderBrush" Value="Transparent"/>
             </Trigger>
         </Style.Triggers>
@@ -497,7 +502,7 @@
     ═══════════════════════════════════════════════════════════════ -->
     <Style TargetType="CheckBox">
         <Setter Property="FontFamily" Value="{StaticResource AppFont}"/>
-        <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
     </Style>
 
@@ -505,7 +510,158 @@
          SEPARATOR
     ═══════════════════════════════════════════════════════════════ -->
     <Style TargetType="Separator">
-        <Setter Property="Background" Value="{StaticResource BorderBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource BorderBrush}"/>
     </Style>
-</ResourceDictionary>
 
+    <!-- ═══════════════════════════════════════════════════════════════
+         COMBO BOX
+    ═══════════════════════════════════════════════════════════════ -->
+    <Style TargetType="ComboBox">
+        <Setter Property="FontFamily"      Value="{StaticResource AppFont}"/>
+        <Setter Property="FontSize"        Value="12"/>
+        <Setter Property="Foreground"      Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="Background"      Value="{DynamicResource SurfaceBrush}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource BorderBrush}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Padding"         Value="6,3"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBox">
+                    <Grid>
+                        <ToggleButton x:Name="toggleButton"
+                                      Background="{TemplateBinding Background}"
+                                      BorderBrush="{TemplateBinding BorderBrush}"
+                                      BorderThickness="{TemplateBinding BorderThickness}"
+                                      IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                      Focusable="False" ClickMode="Press">
+                            <ToggleButton.Template>
+                                <ControlTemplate TargetType="ToggleButton">
+                                    <Border x:Name="bd"
+                                            Background="{TemplateBinding Background}"
+                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                            BorderThickness="{TemplateBinding BorderThickness}"
+                                            CornerRadius="4">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="20"/>
+                                            </Grid.ColumnDefinitions>
+                                            <Path Grid.Column="1"
+                                                  Data="M0,0 L4,4 L8,0"
+                                                  Stroke="{DynamicResource TextSecondaryBrush}"
+                                                  StrokeThickness="1.5"
+                                                  HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center"
+                                                  Stretch="None"/>
+                                        </Grid>
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource HoverBrush}"/>
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </ToggleButton.Template>
+                        </ToggleButton>
+                        <ContentPresenter x:Name="contentPresenter"
+                                          IsHitTestVisible="False"
+                                          Content="{TemplateBinding SelectionBoxItem}"
+                                          ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                          ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                          Margin="{TemplateBinding Padding}"
+                                          HorizontalAlignment="Left"
+                                          VerticalAlignment="Center"/>
+                        <Popup x:Name="PART_Popup"
+                               IsOpen="{TemplateBinding IsDropDownOpen}"
+                               AllowsTransparency="True"
+                               Focusable="False"
+                               PopupAnimation="Slide"
+                               Placement="Bottom">
+                            <Border x:Name="dropDownBorder"
+                                    Background="{DynamicResource SurfaceBrush}"
+                                    BorderBrush="{DynamicResource BorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="4"
+                                    MinWidth="{TemplateBinding ActualWidth}"
+                                    MaxHeight="{TemplateBinding MaxDropDownHeight}">
+                                <ScrollViewer SnapsToDevicePixels="True">
+                                    <StackPanel IsItemsHost="True"
+                                                KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="ComboBoxItem">
+        <Setter Property="FontFamily"  Value="{StaticResource AppFont}"/>
+        <Setter Property="FontSize"    Value="12"/>
+        <Setter Property="Foreground"  Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="Background"  Value="Transparent"/>
+        <Setter Property="Padding"     Value="8,4"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBoxItem">
+                    <Border x:Name="bd"
+                            Background="{TemplateBinding Background}"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsHighlighted" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource SecondaryHoverBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource ListSelectedBrush}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         DATE PICKER
+    ═══════════════════════════════════════════════════════════════ -->
+    <Style TargetType="DatePicker">
+        <Setter Property="FontFamily"      Value="{StaticResource AppFont}"/>
+        <Setter Property="FontSize"        Value="12"/>
+        <Setter Property="Foreground"      Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="Background"      Value="{DynamicResource SurfaceBrush}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource BorderBrush}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Padding"         Value="2,2"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+    </Style>
+
+    <Style TargetType="DatePickerTextBox">
+        <Setter Property="FontFamily"      Value="{StaticResource AppFont}"/>
+        <Setter Property="FontSize"        Value="12"/>
+        <Setter Property="Foreground"      Value="{DynamicResource TextPrimaryBrush}"/>
+        <Setter Property="Background"      Value="{DynamicResource SurfaceBrush}"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding"         Value="4,2"/>
+        <Setter Property="SelectionBrush"  Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="DatePickerTextBox">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderThickness="0"
+                            Padding="{TemplateBinding Padding}">
+                        <ScrollViewer x:Name="PART_ContentHost"
+                                      VerticalAlignment="Center"
+                                      HorizontalScrollBarVisibility="Hidden"
+                                      VerticalScrollBarVisibility="Hidden"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/src/WorkTracking.UI/ViewModels/AppSettingsViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/AppSettingsViewModel.cs
@@ -1,0 +1,48 @@
+using System.Windows.Input;
+using WorkTracking.Data.Repositories.Interfaces;
+using WorkTracking.UI.Commands;
+using WorkTracking.UI.Services;
+
+namespace WorkTracking.UI.ViewModels;
+
+public class AppSettingsViewModel(
+    IThemeService themeService,
+    ISettingRepository settingRepository) : ViewModelBase
+{
+    private const string ThemeSettingKey = "ui_theme";
+
+    private AppTheme _selectedTheme = themeService.CurrentTheme;
+    public AppTheme SelectedTheme
+    {
+        get => _selectedTheme;
+        set
+        {
+            if (SetField(ref _selectedTheme, value))
+                PreviewTheme(value);
+        }
+    }
+
+    public IReadOnlyList<AppTheme> AvailableThemes { get; } = [AppTheme.Light, AppTheme.Dark];
+
+    public ICommand SaveCommand => new RelayCommand(async _ => await SaveAsync());
+
+    public async Task LoadAsync()
+    {
+        var stored = await settingRepository.GetAsync(ThemeSettingKey);
+        if (Enum.TryParse<AppTheme>(stored, out var theme))
+            _selectedTheme = theme;
+        else
+            _selectedTheme = AppTheme.Light;
+
+        OnPropertyChanged(nameof(SelectedTheme));
+        themeService.Apply(_selectedTheme);
+    }
+
+    private void PreviewTheme(AppTheme theme) => themeService.Apply(theme);
+
+    private async Task SaveAsync()
+    {
+        themeService.Apply(_selectedTheme);
+        await settingRepository.SetAsync(ThemeSettingKey, _selectedTheme.ToString());
+    }
+}

--- a/src/WorkTracking.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/MainWindowViewModel.cs
@@ -7,23 +7,31 @@ namespace WorkTracking.UI.ViewModels;
 public class MainWindowViewModel(
     ClientListViewModel clientListViewModel,
     ClientDetailViewModel clientDetailViewModel,
-    HomeViewModel homeViewModel) : ViewModelBase
+    HomeViewModel homeViewModel,
+    AppSettingsViewModel appSettingsViewModel) : ViewModelBase
 {
-    public ClientListViewModel ClientList { get; } = clientListViewModel;
+    public ClientListViewModel  ClientList    { get; } = clientListViewModel;
     public ClientDetailViewModel ClientDetail { get; } = clientDetailViewModel;
-    public HomeViewModel Home { get; } = homeViewModel;
+    public HomeViewModel         Home         { get; } = homeViewModel;
+    public AppSettingsViewModel  AppSettings  { get; } = appSettingsViewModel;
 
-    public bool ShowHome => ClientList.SelectedClient is null;
+    private bool _showSettings;
+
+    public bool ShowHome         => ClientList.SelectedClient is null && !_showSettings;
+    public bool ShowSettings     => _showSettings;
+    public bool ShowClientDetail => ClientList.SelectedClient is not null;
 
     public event EventHandler? ShowAboutRequested;
 
-    public ICommand ShowAboutCommand => new RelayCommand(_ => ShowAboutRequested?.Invoke(this, EventArgs.Empty));
-    public ICommand GoHomeCommand    => new RelayCommand(_ => ClientList.SelectedClient = null);
+    public ICommand ShowAboutCommand  => new RelayCommand(_ => ShowAboutRequested?.Invoke(this, EventArgs.Empty));
+    public ICommand GoHomeCommand     => new RelayCommand(_ => NavigateHome());
+    public ICommand GoSettingsCommand => new RelayCommand(_ => NavigateSettings());
 
     public async Task InitializeAsync()
     {
         await ClientList.LoadAsync();
         await Home.LoadAsync();
+        await AppSettings.LoadAsync();
 
         ClientList.PropertyChanged += (_, e) =>
         {
@@ -39,6 +47,20 @@ public class MainWindowViewModel(
         };
     }
 
+    private void NavigateHome()
+    {
+        _showSettings = false;
+        ClientList.SelectedClient = null;
+        NotifyPanelState();
+    }
+
+    private void NavigateSettings()
+    {
+        _showSettings = true;
+        ClientList.SelectedClient = null;
+        NotifyPanelState();
+    }
+
     private void OnSelectedClientChanged(Client? client)
     {
         if (client is null)
@@ -48,8 +70,16 @@ public class MainWindowViewModel(
         }
         else
         {
+            _showSettings = false;
             ClientDetail.LoadClient(client);
         }
+        NotifyPanelState();
+    }
+
+    private void NotifyPanelState()
+    {
         OnPropertyChanged(nameof(ShowHome));
+        OnPropertyChanged(nameof(ShowSettings));
+        OnPropertyChanged(nameof(ShowClientDetail));
     }
 }

--- a/src/WorkTracking.UI/Views/AddClientDialog.xaml
+++ b/src/WorkTracking.UI/Views/AddClientDialog.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="WorkTracking.UI.Views.AddClientDialog"
+<Window x:Class="WorkTracking.UI.Views.AddClientDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -7,9 +7,11 @@
         mc:Ignorable="d"
         Title="Add Client" Width="380" SizeToContent="Height"
         ResizeMode="NoResize" WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource SurfaceBrush}"
+        Foreground="{DynamicResource TextPrimaryBrush}"
         d:DataContext="{d:DesignInstance Type=vm:AddClientViewModel}">
 
-    <StackPanel Margin="20">
+    <StackPanel Margin="20" Background="{DynamicResource SurfaceBrush}">
 
         <TextBlock Text="New Client" Style="{StaticResource SectionHeader}" Margin="0,0,0,16"/>
 
@@ -35,7 +37,7 @@
         </Grid>
 
         <TextBlock Text="You can fill in all other details on the Settings tab after saving."
-                   Foreground="{StaticResource TextSecondaryBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,12,0,0"/>
+                   Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,12,0,0"/>
 
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
             <Button Content="Cancel" Command="{Binding CancelCommand}" Width="80" IsCancel="True"

--- a/src/WorkTracking.UI/Views/AppSettingsView.xaml
+++ b/src/WorkTracking.UI/Views/AppSettingsView.xaml
@@ -1,0 +1,45 @@
+<UserControl x:Class="WorkTracking.UI.Views.AppSettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:services="clr-namespace:WorkTracking.UI.Services"
+             Background="{DynamicResource BackgroundBrush}">
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="32,24,32,24" MaxWidth="480" HorizontalAlignment="Left">
+
+            <TextBlock Text="App Settings"
+                       FontSize="20" FontWeight="Bold"
+                       Foreground="{DynamicResource TextPrimaryBrush}"
+                       Margin="0,0,0,24"/>
+
+            <!-- Theme -->
+            <TextBlock Text="Theme"
+                       Style="{StaticResource SectionHeader}"
+                       Margin="0,0,0,10"/>
+
+            <StackPanel Orientation="Horizontal">
+                <RadioButton Content="Light"
+                             Margin="0,0,20,0"
+                             FontSize="13"
+                             Foreground="{DynamicResource TextPrimaryBrush}"
+                             IsChecked="{Binding SelectedTheme,
+                                 Converter={StaticResource EnumToBoolConverter},
+                                 ConverterParameter=Light}"/>
+                <RadioButton Content="Dark"
+                             FontSize="13"
+                             Foreground="{DynamicResource TextPrimaryBrush}"
+                             IsChecked="{Binding SelectedTheme,
+                                 Converter={StaticResource EnumToBoolConverter},
+                                 ConverterParameter=Dark}"/>
+            </StackPanel>
+
+            <!-- Save -->
+            <Button Content="Save settings"
+                    Command="{Binding SaveCommand}"
+                    Style="{StaticResource PrimaryButton}"
+                    HorizontalAlignment="Left"
+                    Margin="0,28,0,0"/>
+
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/WorkTracking.UI/Views/AppSettingsView.xaml.cs
+++ b/src/WorkTracking.UI/Views/AppSettingsView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace WorkTracking.UI.Views;
+
+public partial class AppSettingsView : UserControl
+{
+    public AppSettingsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/WorkTracking.UI/Views/ClientSettingsView.xaml
+++ b/src/WorkTracking.UI/Views/ClientSettingsView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="WorkTracking.UI.Views.ClientSettingsView"
+<UserControl x:Class="WorkTracking.UI.Views.ClientSettingsView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -100,7 +100,7 @@
             <!-- Work categories -->
             <TextBlock Text="Work Categories" Style="{StaticResource SectionHeader}" Margin="0,16,0,6"/>
             <TextBlock Text="Only enabled categories appear in the timesheet filter and entry form."
-                       Foreground="{StaticResource TextSecondaryBrush}" FontSize="11" Margin="0,0,0,10"/>
+                       Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11" Margin="0,0,0,10"/>
 
             <ItemsControl ItemsSource="{Binding Categories}">
                 <ItemsControl.ItemTemplate>
@@ -129,7 +129,7 @@
                         Command="{Binding SaveCommand}"
                         Style="{StaticResource PrimaryButton}"
                         Padding="14,6" Margin="0,0,10,0"/>
-                <TextBlock Text="Saving&#x2026;" VerticalAlignment="Center" Foreground="{StaticResource TextSecondaryBrush}">
+                <TextBlock Text="Saving&#x2026;" VerticalAlignment="Center" Foreground="{DynamicResource TextSecondaryBrush}">
                     <TextBlock.Style>
                         <Style TargetType="TextBlock">
                             <Setter Property="Visibility" Value="Collapsed"/>

--- a/src/WorkTracking.UI/Views/HomeView.xaml
+++ b/src/WorkTracking.UI/Views/HomeView.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:conv="clr-namespace:WorkTracking.UI.Converters"
-             Background="{StaticResource BackgroundBrush}">
+             Background="{DynamicResource BackgroundBrush}">
 
     <UserControl.Resources>
         <conv:BoolToVisibilityConverter x:Key="BoolToVisibility"/>
@@ -14,7 +14,7 @@
 
             <!-- Loading indicator -->
             <TextBlock Text="Loading…"
-                       Foreground="{StaticResource TextSecondaryBrush}"
+                       Foreground="{DynamicResource TextSecondaryBrush}"
                        FontSize="13" Margin="0,0,0,12"
                        Visibility="{Binding IsLoading, Converter={StaticResource BoolToVisibility}}"/>
 
@@ -22,49 +22,49 @@
                  Summary cards
             ══════════════════════════════════════════ -->
             <TextBlock Text="Overview" FontSize="18" FontWeight="Bold"
-                       Foreground="{StaticResource TextPrimaryBrush}" Margin="0,0,0,10"/>
+                       Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,10"/>
 
             <UniformGrid Columns="3" Margin="0,0,0,20">
 
                 <!-- Unbilled hours -->
-                <Border Background="{StaticResource SurfaceBrush}"
-                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                <Border Background="{DynamicResource SurfaceBrush}"
+                        BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
                         CornerRadius="6" Margin="0,0,8,0" Padding="14,12">
                     <StackPanel>
                         <TextBlock Text="Total Unbilled Hours"
-                                   FontSize="11" Foreground="{StaticResource TextSecondaryBrush}"
+                                   FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}"
                                    Margin="0,0,0,4"/>
                         <TextBlock Text="{Binding TotalUnbilledHours, StringFormat={}{0:F1} h}"
                                    FontSize="24" FontWeight="Bold"
-                                   Foreground="{StaticResource AccentBrush}"/>
+                                   Foreground="{DynamicResource AccentBrush}"/>
                     </StackPanel>
                 </Border>
 
                 <!-- Invoiced rolling 30 days -->
-                <Border Background="{StaticResource SurfaceBrush}"
-                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                <Border Background="{DynamicResource SurfaceBrush}"
+                        BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
                         CornerRadius="6" Margin="4,0,4,0" Padding="14,12">
                     <StackPanel>
                         <TextBlock Text="Invoiced (Last 30 Days)"
-                                   FontSize="11" Foreground="{StaticResource TextSecondaryBrush}"
+                                   FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}"
                                    Margin="0,0,0,4"/>
                         <TextBlock Text="{Binding InvoicedRolling30Days, StringFormat=${0:N2}}"
                                    FontSize="24" FontWeight="Bold"
-                                   Foreground="{StaticResource TextPrimaryBrush}"/>
+                                   Foreground="{DynamicResource TextPrimaryBrush}"/>
                     </StackPanel>
                 </Border>
 
                 <!-- Active clients -->
-                <Border Background="{StaticResource SurfaceBrush}"
-                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                <Border Background="{DynamicResource SurfaceBrush}"
+                        BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
                         CornerRadius="6" Margin="8,0,0,0" Padding="14,12">
                     <StackPanel>
                         <TextBlock Text="Active Clients"
-                                   FontSize="11" Foreground="{StaticResource TextSecondaryBrush}"
+                                   FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}"
                                    Margin="0,0,0,4"/>
                         <TextBlock Text="{Binding ActiveClientCount}"
                                    FontSize="24" FontWeight="Bold"
-                                   Foreground="{StaticResource TextPrimaryBrush}"/>
+                                   Foreground="{DynamicResource TextPrimaryBrush}"/>
                     </StackPanel>
                 </Border>
 
@@ -74,10 +74,10 @@
                  Per-client status
             ══════════════════════════════════════════ -->
             <TextBlock Text="Client Status" FontSize="15" FontWeight="SemiBold"
-                       Foreground="{StaticResource TextPrimaryBrush}" Margin="0,0,0,8"/>
+                       Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,8"/>
 
-            <Border Background="{StaticResource SurfaceBrush}"
-                    BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+            <Border Background="{DynamicResource SurfaceBrush}"
+                    BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
                     CornerRadius="6" Margin="0,0,0,20" Padding="4,0">
                 <ItemsControl ItemsSource="{Binding ClientStatuses}">
                     <ItemsControl.ItemTemplate>
@@ -102,22 +102,22 @@
                                     <ProgressBar Height="6" Minimum="0" Maximum="1"
                                                  Value="{Binding CapProgress, Mode=OneWay}"
                                                  Visibility="{Binding HasCap, Converter={StaticResource BoolToVisibility}}"
-                                                 Foreground="{StaticResource AccentBrush}"
-                                                 Background="{StaticResource BorderBrush}"
+                                                 Foreground="{DynamicResource AccentBrush}"
+                                                 Background="{DynamicResource BorderBrush}"
                                                  BorderThickness="0"/>
                                     <TextBlock Text="{Binding UninvoicedHours, Mode=OneWay, StringFormat={}{0:F1} h unbilled}"
-                                               FontSize="11" Foreground="{StaticResource TextSecondaryBrush}"
+                                               FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}"
                                                Margin="0,2,0,0"
                                                Visibility="{Binding HasCap, Converter={StaticResource BoolToVisibility}}"/>
                                     <TextBlock Text="{Binding UninvoicedHours, Mode=OneWay, StringFormat={}{0:F1} h unbilled}"
-                                               FontSize="11" Foreground="{StaticResource TextSecondaryBrush}"
+                                               FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}"
                                                Visibility="{Binding HasCap, Converter={StaticResource InverseBoolToVisibility}}"/>
                                 </StackPanel>
 
                                 <!-- Over-cap warning -->
                                 <TextBlock Grid.Column="2"
                                            Text="Over cap"
-                                           Foreground="{StaticResource DangerBrush}"
+                                           Foreground="{DynamicResource DangerBrush}"
                                            FontSize="11" FontWeight="SemiBold"
                                            VerticalAlignment="Center"
                                            Margin="4,0"
@@ -130,10 +130,10 @@
                                            HorizontalAlignment="Right">
                                     <TextBlock.Style>
                                         <Style TargetType="TextBlock">
-                                            <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}"/>
+                                            <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}"/>
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding IsOverdue}" Value="True">
-                                                    <Setter Property="Foreground" Value="{StaticResource DangerBrush}"/>
+                                                    <Setter Property="Foreground" Value="{DynamicResource DangerBrush}"/>
                                                     <Setter Property="FontWeight" Value="SemiBold"/>
                                                 </DataTrigger>
                                             </Style.Triggers>
@@ -150,10 +150,10 @@
                  Monthly report (last 12 months)
             ══════════════════════════════════════════ -->
             <TextBlock Text="Monthly Report — Last 12 Months" FontSize="15" FontWeight="SemiBold"
-                       Foreground="{StaticResource TextPrimaryBrush}" Margin="0,0,0,8"/>
+                       Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,8"/>
 
-            <Border Background="{StaticResource SurfaceBrush}"
-                    BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+            <Border Background="{DynamicResource SurfaceBrush}"
+                    BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
                     CornerRadius="6" Margin="0,0,0,20">
                 <DataGrid ItemsSource="{Binding MonthlyReport}"
                           AutoGenerateColumns="False"
@@ -163,7 +163,7 @@
                           BorderThickness="0"
                           Background="Transparent"
                           RowBackground="Transparent"
-                          AlternatingRowBackground="{StaticResource SurfaceAltBrush}"
+                          AlternatingRowBackground="{DynamicResource SurfaceAltBrush}"
                           CanUserResizeRows="False"
                           CanUserReorderColumns="False">
                     <DataGrid.Columns>
@@ -193,9 +193,9 @@
                 <!-- Hours by client -->
                 <StackPanel Grid.Column="0">
                     <TextBlock Text="Hours by Client" FontSize="15" FontWeight="SemiBold"
-                               Foreground="{StaticResource TextPrimaryBrush}" Margin="0,0,0,8"/>
-                    <Border Background="{StaticResource SurfaceBrush}"
-                            BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                               Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,8"/>
+                    <Border Background="{DynamicResource SurfaceBrush}"
+                            BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
                             CornerRadius="6">
                         <DataGrid ItemsSource="{Binding HoursByClient}"
                                   AutoGenerateColumns="False"
@@ -205,7 +205,7 @@
                                   BorderThickness="0"
                                   Background="Transparent"
                                   RowBackground="Transparent"
-                                  AlternatingRowBackground="{StaticResource SurfaceAltBrush}"
+                                  AlternatingRowBackground="{DynamicResource SurfaceAltBrush}"
                                   CanUserResizeRows="False"
                                   CanUserReorderColumns="False">
                             <DataGrid.Columns>
@@ -223,9 +223,9 @@
                 <!-- Hours by category -->
                 <StackPanel Grid.Column="2">
                     <TextBlock Text="Hours by Category" FontSize="15" FontWeight="SemiBold"
-                               Foreground="{StaticResource TextPrimaryBrush}" Margin="0,0,0,8"/>
-                    <Border Background="{StaticResource SurfaceBrush}"
-                            BorderBrush="{StaticResource BorderBrush}" BorderThickness="1"
+                               Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,8"/>
+                    <Border Background="{DynamicResource SurfaceBrush}"
+                            BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
                             CornerRadius="6">
                         <DataGrid ItemsSource="{Binding CategoryDistribution}"
                                   AutoGenerateColumns="False"
@@ -235,7 +235,7 @@
                                   BorderThickness="0"
                                   Background="Transparent"
                                   RowBackground="Transparent"
-                                  AlternatingRowBackground="{StaticResource SurfaceAltBrush}"
+                                  AlternatingRowBackground="{DynamicResource SurfaceAltBrush}"
                                   CanUserResizeRows="False"
                                   CanUserReorderColumns="False">
                             <DataGrid.Columns>

--- a/src/WorkTracking.UI/Views/InvoicePrepDialog.xaml
+++ b/src/WorkTracking.UI/Views/InvoicePrepDialog.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="WorkTracking.UI.Views.InvoicePrepDialog"
+<Window x:Class="WorkTracking.UI.Views.InvoicePrepDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -9,13 +9,15 @@
         Width="480" SizeToContent="Height"
         ResizeMode="NoResize"
         WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource SurfaceBrush}"
+        Foreground="{DynamicResource TextPrimaryBrush}"
         d:DataContext="{d:DesignInstance Type=vm:InvoicePrepViewModel}">
 
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis"/>
     </Window.Resources>
 
-    <StackPanel Margin="20">
+    <StackPanel Margin="20" Background="{DynamicResource SurfaceBrush}">
 
         <!-- Summary -->
         <TextBlock Text="Invoice Summary" Style="{StaticResource SectionHeader}" Margin="0,0,0,12"/>
@@ -55,7 +57,7 @@
                             <ColumnDefinition Width="60"/>
                             <ColumnDefinition Width="80"/>
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" Text="{Binding CategoryName}" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11"/>
+                        <TextBlock Grid.Column="0" Text="{Binding CategoryName}" Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11"/>
                         <TextBlock Grid.Column="1" Text="{Binding Hours, StringFormat='{}{0:N2} h'}" FontSize="11" HorizontalAlignment="Right"/>
                         <TextBlock Grid.Column="2" Text="{Binding Amount, StringFormat='{}{0:C}'}" FontSize="11" HorizontalAlignment="Right"/>
                     </Grid>

--- a/src/WorkTracking.UI/Views/InvoicesView.xaml
+++ b/src/WorkTracking.UI/Views/InvoicesView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="WorkTracking.UI.Views.InvoicesView"
+<UserControl x:Class="WorkTracking.UI.Views.InvoicesView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -27,7 +27,7 @@
             <TextBlock DockPanel.Dock="Top"
                        Text="No invoices yet."
                        HorizontalAlignment="Center" Margin="0,20"
-                       Foreground="{StaticResource TextSecondaryBrush}">
+                       Foreground="{DynamicResource TextSecondaryBrush}">
                 <TextBlock.Style>
                     <Style TargetType="TextBlock">
                         <Setter Property="Visibility" Value="Collapsed"/>
@@ -61,10 +61,10 @@
                                        FontWeight="SemiBold"/>
                             <TextBlock Grid.Row="1" Grid.Column="0"
                                        Text="{Binding InvoiceDate, StringFormat='{}{0:dd MMM yyyy}'}"
-                                       Foreground="{StaticResource TextSecondaryBrush}" FontSize="11"/>
+                                       Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11"/>
                             <TextBlock Grid.Row="1" Grid.Column="1"
                                        Text="{Binding EntryCount, StringFormat='{}{0} entries'}"
-                                       Foreground="{StaticResource TextSecondaryBrush}" FontSize="11"/>
+                                       Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11"/>
                         </Grid>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
@@ -72,7 +72,7 @@
         </DockPanel>
 
         <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch"
-                      Background="{StaticResource BorderBrush}"/>
+                      Background="{DynamicResource BorderBrush}"/>
 
         <!-- Invoice detail -->
         <ScrollViewer Grid.Column="2" VerticalScrollBarVisibility="Auto">
@@ -80,7 +80,7 @@
 
                 <!-- No selection placeholder -->
                 <TextBlock Text="Select an invoice to view details."
-                           Foreground="{StaticResource TextSecondaryBrush}" HorizontalAlignment="Center" Margin="0,40">
+                           Foreground="{DynamicResource TextSecondaryBrush}" HorizontalAlignment="Center" Margin="0,40">
                     <TextBlock.Style>
                         <Style TargetType="TextBlock">
                             <Setter Property="Visibility" Value="Collapsed"/>
@@ -110,7 +110,7 @@
                     <TextBlock Text="{Binding InvoiceNumber}"
                                FontSize="18" FontWeight="Bold" Margin="0,0,0,4"/>
                     <TextBlock Text="{Binding InvoiceDate, StringFormat='Date: {0:dd MMM yyyy}'}"
-                               Foreground="{StaticResource TextSecondaryBrush}" Margin="0,0,0,4"/>
+                               Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,0,0,4"/>
                     <TextBlock Text="{Binding TotalAmount, StringFormat='Total: {0:C}'}"
                                FontWeight="SemiBold" FontSize="14" Margin="0,0,0,12"/>
 
@@ -131,7 +131,7 @@
                               IsReadOnly="True"
                               HeadersVisibility="Column"
                               GridLinesVisibility="Horizontal"
-                              BorderThickness="1" BorderBrush="{StaticResource BorderBrush}"
+                              BorderThickness="1" BorderBrush="{DynamicResource BorderBrush}"
                               Margin="0,0,0,16">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Category" Binding="{Binding Description}" Width="*"/>
@@ -149,7 +149,7 @@
                               IsReadOnly="True"
                               HeadersVisibility="Column"
                               GridLinesVisibility="Horizontal"
-                              BorderThickness="1" BorderBrush="{StaticResource BorderBrush}">
+                              BorderThickness="1" BorderBrush="{DynamicResource BorderBrush}">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Date" Binding="{Binding Date, StringFormat='{}{0:dd MMM yyyy}'}" Width="105"/>
                             <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="*"/>

--- a/src/WorkTracking.UI/Views/TimesheetView.xaml
+++ b/src/WorkTracking.UI/Views/TimesheetView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="WorkTracking.UI.Views.TimesheetView"
+<UserControl x:Class="WorkTracking.UI.Views.TimesheetView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -28,7 +28,7 @@
         <Border Grid.Row="0" Style="{StaticResource ToolbarPanel}">
             <WrapPanel>
                 <TextBlock Text="Period:" VerticalAlignment="Center"
-                           Margin="0,0,4,0" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11"/>
+                           Margin="0,0,4,0" Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11"/>
                 <Button Content="This Month" Command="{Binding FilterThisMonthCommand}"
                         Style="{StaticResource ToolbarButton}" Margin="0,0,3,0"/>
                 <Button Content="Last Month" Command="{Binding FilterLastMonthCommand}"
@@ -39,22 +39,22 @@
                         Style="{StaticResource ToolbarButton}" Margin="0,0,10,0"/>
 
                 <TextBlock Text="From:" VerticalAlignment="Center"
-                           Margin="0,0,4,0" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11"/>
+                           Margin="0,0,4,0" Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11"/>
                 <DatePicker SelectedDate="{Binding FilterStartDate, UpdateSourceTrigger=PropertyChanged}"
                             Width="120" Margin="0,0,6,0"/>
                 <TextBlock Text="To:" VerticalAlignment="Center"
-                           Margin="0,0,4,0" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11"/>
+                           Margin="0,0,4,0" Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11"/>
                 <DatePicker SelectedDate="{Binding FilterEndDate, UpdateSourceTrigger=PropertyChanged}"
                             Width="120" Margin="0,0,10,0"/>
 
                 <TextBlock Text="Show:" VerticalAlignment="Center"
-                           Margin="0,0,4,0" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11"/>
+                           Margin="0,0,4,0" Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11"/>
                 <ComboBox ItemsSource="{Binding InvoicedFilterOptions}"
                           SelectedItem="{Binding InvoicedFilterText}"
                           Width="100" Margin="0,0,10,0"/>
 
                 <TextBlock Text="Category:" VerticalAlignment="Center"
-                           Margin="0,0,4,0" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11"/>
+                           Margin="0,0,4,0" Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11"/>
                 <ComboBox Width="150" Margin="0,0,10,0"
                           ItemsSource="{Binding CategoriesWithAll}"
                           DisplayMemberPath="Name"
@@ -69,7 +69,7 @@
                     </StackPanel>
                 </ToggleButton>
 
-                <Separator Width="1" Height="18" Margin="10,0" Background="{StaticResource BorderBrush}"/>
+                <Separator Width="1" Height="18" Margin="10,0" Background="{DynamicResource BorderBrush}"/>
 
                 <Button Command="{Binding AddEntryCommand}"
                         Style="{StaticResource PrimaryButton}"
@@ -83,7 +83,7 @@
                 <Button Command="{Binding EditEntryCommand}"
                         Style="{StaticResource ToolbarButton}" Margin="0,0,4,0">
                     <StackPanel Orientation="Horizontal">
-                        <Path Data="{StaticResource IconEdit}" Fill="{StaticResource TextPrimaryBrush}"
+                        <Path Data="{StaticResource IconEdit}" Fill="{DynamicResource TextPrimaryBrush}"
                               Width="12" Height="12" Stretch="Uniform" Margin="0,0,4,0" VerticalAlignment="Center"/>
                         <TextBlock Text="Edit" VerticalAlignment="Center"/>
                     </StackPanel>
@@ -91,7 +91,7 @@
                 <Button Command="{Binding DeleteEntryCommand}"
                         Style="{StaticResource ToolbarButton}" Margin="0,0,4,0">
                     <StackPanel Orientation="Horizontal">
-                        <Path Data="{StaticResource IconDelete}" Fill="{StaticResource TextPrimaryBrush}"
+                        <Path Data="{StaticResource IconDelete}" Fill="{DynamicResource TextPrimaryBrush}"
                               Width="12" Height="12" Stretch="Uniform" Margin="0,0,4,0" VerticalAlignment="Center"/>
                         <TextBlock Text="Delete" VerticalAlignment="Center"/>
                     </StackPanel>
@@ -99,16 +99,16 @@
                 <Button Command="{Binding ViewEntryCommand}"
                         Style="{StaticResource ToolbarButton}">
                     <StackPanel Orientation="Horizontal">
-                        <Path Data="{StaticResource IconView}" Fill="{StaticResource TextPrimaryBrush}"
+                        <Path Data="{StaticResource IconView}" Fill="{DynamicResource TextPrimaryBrush}"
                               Width="12" Height="12" Stretch="Uniform" Margin="0,0,4,0" VerticalAlignment="Center"/>
                         <TextBlock Text="View" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
 
-                <Separator Width="1" Height="18" Margin="10,0" Background="{StaticResource BorderBrush}"/>
+                <Separator Width="1" Height="18" Margin="10,0" Background="{DynamicResource BorderBrush}"/>
 
                 <TextBlock Text="Group:" VerticalAlignment="Center"
-                           Margin="0,0,4,0" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11"/>
+                           Margin="0,0,4,0" Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11"/>
                 <ComboBox ItemsSource="{Binding GroupByOptions}"
                           SelectedItem="{Binding SelectedGroupBy}"
                           Width="110" FontSize="11"/>
@@ -186,7 +186,7 @@
 
             <!-- NOTES DRAWER -->
             <Border Grid.Column="1"
-                    BorderBrush="{StaticResource BorderBrush}" BorderThickness="1,0,0,0"
+                    BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1,0,0,0"
                     Visibility="{Binding IsNotesOpen, Converter={StaticResource BoolToVisibilityConverter}}">
                 <DockPanel Margin="10">
                     <TextBlock DockPanel.Dock="Top" Text="Notes"
@@ -194,7 +194,7 @@
 
                     <TextBlock DockPanel.Dock="Top"
                                Text="Select a row to view notes."
-                               Foreground="{StaticResource TextSecondaryBrush}" FontStyle="Italic"
+                               Foreground="{DynamicResource TextSecondaryBrush}" FontStyle="Italic"
                                Visibility="{Binding HasSelectedEntry,
                                    Converter={StaticResource InverseBoolToVisibilityConverter}}"/>
 
@@ -209,14 +209,14 @@
                                FontWeight="SemiBold" FontSize="13" Margin="0,0,0,4"/>
                     <TextBlock DockPanel.Dock="Top"
                                Text="No attachments."
-                               Foreground="{StaticResource TextSecondaryBrush}" FontStyle="Italic" FontSize="11"/>
+                               Foreground="{DynamicResource TextSecondaryBrush}" FontStyle="Italic" FontSize="11"/>
                 </DockPanel>
             </Border>
         </Grid>
 
         <!-- FOOTER -->
-        <Border Grid.Row="2" Background="{StaticResource BackgroundBrush}"
-                BorderBrush="{StaticResource BorderBrush}" BorderThickness="0,1,0,0" Padding="12,6">
+        <Border Grid.Row="2" Background="{DynamicResource BackgroundBrush}"
+                BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0" Padding="12,6">
             <DockPanel>
                 <Button DockPanel.Dock="Right"
                         Content="Prepare Invoice&#x2026;"
@@ -225,10 +225,10 @@
                         Padding="10,5"/>
 
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="Uninvoiced total: " Foreground="{StaticResource TextSecondaryBrush}" FontSize="12"/>
+                    <TextBlock Text="Uninvoiced total: " Foreground="{DynamicResource TextSecondaryBrush}" FontSize="12"/>
                     <TextBlock FontSize="12" FontWeight="SemiBold" Margin="0,0,4,0">
                         <TextBlock.Text>
-                            <MultiBinding StringFormat="{}{0:N1} hrs  ·  ${1:N2}">
+                            <MultiBinding StringFormat="{}{0:N1} hrs  �  ${1:N2}">
                                 <Binding Path="TotalUninvoicedHours"/>
                                 <Binding Path="TotalUninvoicedAmount"/>
                             </MultiBinding>
@@ -258,8 +258,8 @@
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal" Margin="0,0,12,0">
                                     <TextBlock Text="{Binding CategoryName}"
-                                               Foreground="{StaticResource TextSecondaryBrush}" FontSize="11"/>
-                                    <TextBlock Text=": " Foreground="{StaticResource TextSecondaryBrush}" FontSize="11"/>
+                                               Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11"/>
+                                    <TextBlock Text=": " Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11"/>
                                     <TextBlock Text="{Binding Hours, StringFormat='{}{0:N1} hrs'}"
                                                FontSize="11"/>
                                 </StackPanel>

--- a/src/WorkTracking.UI/Views/WorkEntryDialog.xaml
+++ b/src/WorkTracking.UI/Views/WorkEntryDialog.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="WorkTracking.UI.Views.WorkEntryDialog"
+<Window x:Class="WorkTracking.UI.Views.WorkEntryDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/tests/WorkTracking.Tests/UI/MainWindowViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/MainWindowViewModelTests.cs
@@ -60,6 +60,14 @@ public class MainWindowViewModelTests
     }
 
     private static ClientDetailViewModel MakeDetailVm() => new(MakeTimesheetVm(), MakeInvoicesVm(), MakeSummaryVm(), MakeSettingsVm());
+    private static AppSettingsViewModel MakeAppSettingsVm()
+    {
+        var themeService = new Mock<IThemeService>();
+        themeService.SetupGet(t => t.CurrentTheme).Returns(AppTheme.Light);
+        var settingRepo = new Mock<ISettingRepository>();
+        settingRepo.Setup(r => r.GetAsync(It.IsAny<string>())).ReturnsAsync((string?)null);
+        return new AppSettingsViewModel(themeService.Object, settingRepo.Object);
+    }
     private static HomeViewModel MakeHomeVm()
     {
         var clientRepo = new Mock<IClientRepository>();
@@ -78,7 +86,7 @@ public class MainWindowViewModelTests
         var clients = new List<Client> { new() { Id = 1, Name = "Acme" } };
         var listVm = MakeClientListVm(clients);
         var detailVm = MakeDetailVm();
-        var vm = new MainWindowViewModel(listVm, detailVm, MakeHomeVm());
+        var vm = new MainWindowViewModel(listVm, detailVm, MakeHomeVm(), MakeAppSettingsVm());
 
         await vm.InitializeAsync();
 
@@ -91,7 +99,7 @@ public class MainWindowViewModelTests
         var client = new Client { Id = 1, Name = "Acme" };
         var listVm = MakeClientListVm([client]);
         var detailVm = MakeDetailVm();
-        var vm = new MainWindowViewModel(listVm, detailVm, MakeHomeVm());
+        var vm = new MainWindowViewModel(listVm, detailVm, MakeHomeVm(), MakeAppSettingsVm());
         await vm.InitializeAsync();
 
         listVm.SelectedClient = client;
@@ -106,7 +114,7 @@ public class MainWindowViewModelTests
         var client = new Client { Id = 1, Name = "Acme" };
         var listVm = MakeClientListVm([client]);
         var detailVm = MakeDetailVm();
-        var vm = new MainWindowViewModel(listVm, detailVm, MakeHomeVm());
+        var vm = new MainWindowViewModel(listVm, detailVm, MakeHomeVm(), MakeAppSettingsVm());
         await vm.InitializeAsync();
         listVm.SelectedClient = client;
 
@@ -120,7 +128,7 @@ public class MainWindowViewModelTests
     {
         var listVm = MakeClientListVm([]);
         var detailVm = MakeDetailVm();
-        var vm = new MainWindowViewModel(listVm, detailVm, MakeHomeVm());
+        var vm = new MainWindowViewModel(listVm, detailVm, MakeHomeVm(), MakeAppSettingsVm());
 
         await vm.InitializeAsync();
 


### PR DESCRIPTION
## Summary
Adds runtime light/dark theme switching. Users can toggle between Light and Dark in App Settings — the UI updates instantly without a restart.

## Changes

### New files
- `IThemeService` / `ThemeService` — applies theme by replacing all 17 `SolidColorBrush` entries in `Application.Current.Resources` at runtime
- `AppSettingsViewModel` + `AppSettingsView` — Settings panel with Light/Dark radio buttons
- `EnumToBoolConverter` — enum-backed RadioButton binding

### Modified files
- `ModernTheme.xaml` — all brush refs converted to `{DynamicResource}`; full ComboBox, DatePicker, TabControl, ListBox styles added
- All view XAML files — `{StaticResource XxxBrush}` -> `{DynamicResource XxxBrush}` throughout
- `MainWindow.xaml` + dialog windows — explicit Background/Foreground DynamicResource bindings on root elements
- `MainWindowViewModel` — wired up GoSettingsCommand, ShowSettings, AppSettings
- `ServiceCollectionExtensions` — IThemeService/AppSettingsViewModel registered
- `MainWindowViewModelTests` — updated for new constructor signature

## Tests
- 185/185 passing
- dotnet build: 0 errors