### PR TITLE
fix: release packaging, dev/prod DB isolation, and assembly metadata (#37)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,24 @@ jobs:
           -p:AssemblyVersion=${{ steps.version.outputs.VERSION }}
           --output publish/
 
+      - name: Install Velopack CLI
+        run: dotnet tool install -g vpk
+
+      - name: Pack installer
+        run: >
+          vpk pack
+          --packId Billable
+          --packVersion ${{ steps.version.outputs.VERSION }}
+          --packDir publish/
+          --mainExe billable.exe
+          --icon src/WorkTracking.UI/app.ico
+          --outputDir installer/
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: publish/billable.exe
+          files: |
+            installer/BillableSetup.exe
+            installer/RELEASES.win.json
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/src/WorkTracking.Data/Database/DatabaseConnectionFactory.cs
+++ b/src/WorkTracking.Data/Database/DatabaseConnectionFactory.cs
@@ -16,6 +16,11 @@ public class DatabaseConnectionFactory(string connectionString) : IDatabaseConne
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             "Billable");
         Directory.CreateDirectory(folder);
-        return $"Data Source={Path.Combine(folder, "billable.db")}";
+#if DEBUG
+        const string dbName = "billable-dev.db";
+#else
+        const string dbName = "billable.db";
+#endif
+        return $"Data Source={Path.Combine(folder, dbName)}";
     }
 }

--- a/src/WorkTracking.UI/MainWindow.xaml
+++ b/src/WorkTracking.UI/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:vm="clr-namespace:WorkTracking.UI.ViewModels"
         xmlns:views="clr-namespace:WorkTracking.UI.Views"
         mc:Ignorable="d"
-        Title="Billable" Height="650" Width="1100"
+        Title="{Binding Title}" Height="650" Width="1100"
         MinHeight="400" MinWidth="700"
         Background="{DynamicResource BackgroundBrush}"
         Foreground="{DynamicResource TextPrimaryBrush}">

--- a/src/WorkTracking.UI/Program.cs
+++ b/src/WorkTracking.UI/Program.cs
@@ -1,0 +1,17 @@
+using System.Windows;
+using Velopack;
+
+namespace WorkTracking.UI;
+
+public static class Program
+{
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        VelopackApp.Build().Run();
+
+        var app = new App();
+        app.InitializeComponent();
+        app.Run();
+    }
+}

--- a/src/WorkTracking.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/MainWindowViewModel.cs
@@ -15,6 +15,12 @@ public class MainWindowViewModel(
     public HomeViewModel         Home         { get; } = homeViewModel;
     public AppSettingsViewModel  AppSettings  { get; } = appSettingsViewModel;
 
+#if DEBUG
+    public string Title => "Billable [DEV]";
+#else
+    public string Title => "Billable";
+#endif
+
     private bool _showSettings;
 
     public bool ShowHome         => ClientList.SelectedClient is null && !_showSettings;

--- a/src/WorkTracking.UI/WorkTracking.UI.csproj
+++ b/src/WorkTracking.UI/WorkTracking.UI.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
+    <PackageReference Include="Velopack" Version="0.0.1298" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -26,6 +27,10 @@
     <UseWPF>true</UseWPF>
     <AssemblyName>billable</AssemblyName>
     <ApplicationIcon>app.ico</ApplicationIcon>
+    <Company>Codebureau</Company>
+    <Product>Billable</Product>
+    <Copyright>Copyright © Codebureau $([System.DateTime]::Now.Year)</Copyright>
+    <StartupObject>WorkTracking.UI.Program</StartupObject>
   </PropertyGroup>
 
 </Project>

--- a/tag-release.ps1
+++ b/tag-release.ps1
@@ -1,70 +1,53 @@
-﻿# tag-release.ps1 - create and push a semver release tag
-# Uses GUI dialogs so it works from the VS Tools menu Output window.
-
-Add-Type -AssemblyName Microsoft.VisualBasic
-Add-Type -AssemblyName System.Windows.Forms
+﻿#!/usr/bin/env pwsh
+# tag-release.ps1 — create and push a semver release tag
+# Run from the repo root, or invoke via Tools > Tag Release in Visual Studio.
 
 Set-Location $PSScriptRoot
 
-# 1. Check working tree is clean
+# ── 1. Check working tree is clean ────────────────────────────────────────────
 $status = git status --porcelain
 if ($status) {
-    $msg = "Uncommitted changes detected:`n$($status -join "`n")`n`nProceed anyway?"
-    $result = [System.Windows.Forms.MessageBox]::Show(
-        $msg, "Uncommitted Changes",
-        [System.Windows.Forms.MessageBoxButtons]::YesNo,
-        [System.Windows.Forms.MessageBoxIcon]::Warning)
-    if ($result -ne [System.Windows.Forms.DialogResult]::Yes) {
-        Write-Host "Aborted - commit or stash changes first."
-        exit 1
-    }
+    Write-Host ""
+    Write-Host "  Uncommitted changes detected:" -ForegroundColor Yellow
+    $status | ForEach-Object { Write-Host "    $_" }
+    Write-Host ""
+    $proceed = Read-Host "  Proceed anyway? (y/N)"
+    if ($proceed -ne 'y') { exit 1 }
 }
 
-# 2. Get last tag for reference
+# ── 2. Show the last tag so the user knows what to increment ──────────────────
 $lastTag = git describe --tags --abbrev=0 2>$null
-$prompt = if ($lastTag) { "Last release: $lastTag`n`nEnter new version (e.g. 1.2.0):" } else { "Enter version (e.g. 1.0.0):" }
-
-# 3. Prompt for new version via GUI input box
-$version = [Microsoft.VisualBasic.Interaction]::InputBox($prompt, "Tag Release", "")
-
-if ([string]::IsNullOrWhiteSpace($version)) {
-    Write-Host "Aborted."
-    exit 0
+if ($lastTag) {
+    Write-Host ""
+    Write-Host "  Last release tag : $lastTag" -ForegroundColor Cyan
 }
 
-$version = $version.Trim().TrimStart("v")
+# ── 3. Prompt for new version ─────────────────────────────────────────────────
+Write-Host ""
+$version = Read-Host "  Enter new version (e.g. 1.2.0)"
+$version = $version.Trim().TrimStart('v')
 
-if ($version -notmatch "^\d+\.\d+\.\d+$") {
-    [System.Windows.Forms.MessageBox]::Show(
-        "Invalid format '$version' - expected MAJOR.MINOR.PATCH (e.g. 1.2.0)",
-        "Invalid Version",
-        [System.Windows.Forms.MessageBoxButtons]::OK,
-        [System.Windows.Forms.MessageBoxIcon]::Error) | Out-Null
+if ($version -notmatch '^\d+\.\d+\.\d+$') {
+    Write-Host "  Invalid format — expected MAJOR.MINOR.PATCH (e.g. 1.2.0)" -ForegroundColor Red
     exit 1
 }
 
 $tag = "v$version"
 
-# 4. Confirm
-$confirm = [System.Windows.Forms.MessageBox]::Show(
-    "Create and push tag: $tag`n`nThis will trigger the GitHub Actions release workflow.",
-    "Confirm Release",
-    [System.Windows.Forms.MessageBoxButtons]::OKCancel,
-    [System.Windows.Forms.MessageBoxIcon]::Question)
+# ── 4. Confirm ────────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "  Will create and push tag: $tag" -ForegroundColor Green
+$confirm = Read-Host "  Confirm? (Y/n)"
+if ($confirm -eq 'n') { exit 0 }
 
-if ($confirm -ne [System.Windows.Forms.DialogResult]::OK) {
-    Write-Host "Aborted."
-    exit 0
-}
-
-# 5. Create and push the tag
+# ── 5. Create and push the tag ────────────────────────────────────────────────
 git tag $tag
-if ($LASTEXITCODE -ne 0) { Write-Host "ERROR: git tag failed."; exit 1 }
+if ($LASTEXITCODE -ne 0) { Write-Host "  git tag failed" -ForegroundColor Red; exit 1 }
 
 git push origin $tag
-if ($LASTEXITCODE -ne 0) { Write-Host "ERROR: git push failed."; exit 1 }
+if ($LASTEXITCODE -ne 0) { Write-Host "  git push failed" -ForegroundColor Red; exit 1 }
 
 Write-Host ""
-Write-Host "Tag $tag pushed successfully."
-Write-Host "GitHub Actions release workflow is now running."
-Write-Host "https://github.com/codebureau/billable/actions"
+Write-Host "  Tag $tag pushed — GitHub Actions release workflow is now running." -ForegroundColor Green
+Write-Host "  https://github.com/codebureau/billable/actions" -ForegroundColor Cyan
+Write-Host ""


### PR DESCRIPTION
Closes #37

## Changes

- **Velopack installer** — workflow now produces \BillableSetup.exe\ via \pk pack\; users download and run a proper Windows installer (Start Menu, Add/Remove Programs, no admin required)
- **Dev/prod DB isolation** — Debug builds use \illable-dev.db\, Release builds use \illable.db\; developer data and production data can never collide
- **Title bar indicator** — Debug builds show \Billable [DEV]\ in the window title
- **Assembly metadata** — \Company=Codebureau\, \Product=Billable\, \Copyright © Codebureau\ added to \WorkTracking.UI.csproj\
- **Custom entry point** — \Program.cs\ added to wire \VelopackApp.Build().Run()\ before WPF startup (required by Velopack)
- **tag-release.ps1** — replaced WinForms GUI prompts with console prompts (no dependency on \System.Windows.Forms\)