### PR TITLE
fix: release packaging, dev/prod DB isolation, and assembly metadata (#37)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            installer/BillableSetup.exe
+            installer/Billable-Setup.exe
             installer/RELEASES.win.json
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/tag-release.ps1
+++ b/tag-release.ps1
@@ -4,6 +4,9 @@
 
 Set-Location $PSScriptRoot
 
+Add-Type -AssemblyName Microsoft.VisualBasic
+Add-Type -AssemblyName System.Windows.Forms
+
 # ── 1. Check working tree is clean ────────────────────────────────────────────
 $status = git status --porcelain
 if ($status) {
@@ -11,31 +14,41 @@ if ($status) {
     Write-Host "  Uncommitted changes detected:" -ForegroundColor Yellow
     $status | ForEach-Object { Write-Host "    $_" }
     Write-Host ""
-    $proceed = Read-Host "  Proceed anyway? (y/N)"
-    if ($proceed -ne 'y') { exit 1 }
+    $result = [System.Windows.Forms.MessageBox]::Show(
+        "Uncommitted changes detected:`n`n$($status -join "`n")`n`nProceed anyway?",
+        "Uncommitted Changes",
+        [System.Windows.Forms.MessageBoxButtons]::YesNo,
+        [System.Windows.Forms.MessageBoxIcon]::Warning)
+    if ($result -ne [System.Windows.Forms.DialogResult]::Yes) {
+        Write-Host "  Aborted." -ForegroundColor Yellow; exit 1
+    }
 }
 
 # ── 2. Show the last tag so the user knows what to increment ──────────────────
 $lastTag = git describe --tags --abbrev=0 2>$null
+$prompt = if ($lastTag) { "Last release: $lastTag`n`nEnter new version (e.g. 1.2.0):" } else { "Enter new version (e.g. 1.0.0):" }
 if ($lastTag) {
     Write-Host ""
     Write-Host "  Last release tag : $lastTag" -ForegroundColor Cyan
 }
 
-# ── 3. Prompt for new version ─────────────────────────────────────────────────
+# ── 3. Prompt for new version (GUI input box) ─────────────────────────────────
 Write-Host ""
-$rawVersion = Read-Host "  Enter new version (e.g. 1.2.0)"
+$rawVersion = [Microsoft.VisualBasic.Interaction]::InputBox($prompt, "Tag Release", "")
 
 if ([string]::IsNullOrWhiteSpace($rawVersion)) {
-    Write-Host "  Aborted — no version entered." -ForegroundColor Yellow
-    exit 0
+    Write-Host "  Aborted — no version entered." -ForegroundColor Yellow; exit 0
 }
 
 $version = $rawVersion.Trim().TrimStart('v')
 
 if ($version -notmatch '^\d+\.\d+\.\d+$') {
-    Write-Host "  Invalid format '$version' — expected MAJOR.MINOR.PATCH (e.g. 1.2.0)" -ForegroundColor Red
-    exit 1
+    [System.Windows.Forms.MessageBox]::Show(
+        "Invalid format '$version' — expected MAJOR.MINOR.PATCH (e.g. 1.2.0)",
+        "Invalid Version",
+        [System.Windows.Forms.MessageBoxButtons]::OK,
+        [System.Windows.Forms.MessageBoxIcon]::Error) | Out-Null
+    Write-Host "  Invalid version format '$version'." -ForegroundColor Red; exit 1
 }
 
 $tag = "v$version"
@@ -43,8 +56,14 @@ $tag = "v$version"
 # ── 4. Confirm ────────────────────────────────────────────────────────────────
 Write-Host ""
 Write-Host "  Will create and push tag: $tag" -ForegroundColor Green
-$confirm = Read-Host "  Confirm? (Y/n)"
-if ($confirm -eq 'n') { exit 0 }
+$confirm = [System.Windows.Forms.MessageBox]::Show(
+    "Create and push tag: $tag`n`nThis will trigger the GitHub Actions release workflow.",
+    "Confirm Release",
+    [System.Windows.Forms.MessageBoxButtons]::OKCancel,
+    [System.Windows.Forms.MessageBoxIcon]::Question)
+if ($confirm -ne [System.Windows.Forms.DialogResult]::OK) {
+    Write-Host "  Aborted." -ForegroundColor Yellow; exit 0
+}
 
 # ── 5. Create and push the tag ────────────────────────────────────────────────
 git tag $tag

--- a/tag-release.ps1
+++ b/tag-release.ps1
@@ -24,11 +24,17 @@ if ($lastTag) {
 
 # ── 3. Prompt for new version ─────────────────────────────────────────────────
 Write-Host ""
-$version = Read-Host "  Enter new version (e.g. 1.2.0)"
-$version = $version.Trim().TrimStart('v')
+$rawVersion = Read-Host "  Enter new version (e.g. 1.2.0)"
+
+if ([string]::IsNullOrWhiteSpace($rawVersion)) {
+    Write-Host "  Aborted — no version entered." -ForegroundColor Yellow
+    exit 0
+}
+
+$version = $rawVersion.Trim().TrimStart('v')
 
 if ($version -notmatch '^\d+\.\d+\.\d+$') {
-    Write-Host "  Invalid format — expected MAJOR.MINOR.PATCH (e.g. 1.2.0)" -ForegroundColor Red
+    Write-Host "  Invalid format '$version' — expected MAJOR.MINOR.PATCH (e.g. 1.2.0)" -ForegroundColor Red
     exit 1
 }
 


### PR DESCRIPTION
Closes #37

## Changes

- **Velopack installer** — workflow now produces \Billable-Setup.exe\ via \pk pack\; users download and run a proper Windows installer (Start Menu, Add/Remove Programs, no admin required)
- **Dev/prod DB isolation** — Debug builds use \illable-dev.db\, Release builds use \illable.db\; developer data and production data can never collide
- **Title bar indicator** — Debug builds show \Billable [DEV]\ in the window title
- **Assembly metadata** — \Company=Codebureau\, \Product=Billable\, \Copyright © Codebureau\ added to \WorkTracking.UI.csproj\
- **Custom entry point** — \Program.cs\ added to wire \VelopackApp.Build().Run()\ before WPF startup (required by Velopack)
- **tag-release.ps1** — GUI popups for version input and confirmations (compatible with VS output window)