### PR TITLE
fix: correct vpk output filenames in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,14 +58,11 @@ jobs:
           --icon src/WorkTracking.UI/app.ico
           --outputDir installer/
 
-      - name: List installer output
-        run: Get-ChildItem -Recurse installer/ | Select-Object FullName
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            installer/Billable-Setup.exe
-            installer/RELEASES.win.json
+            installer/Billable-win-Setup.exe
+            installer/releases.win.json
           generate_release_notes: true
           fail_on_unmatched_files: true


### PR DESCRIPTION
Fixes the release workflow upload step with the exact filenames vpk produces (confirmed from diagnostic listing in v1.0.3 run):

- \Billable-win-Setup.exe\ (not \Billable-Setup.exe\)
- \eleases.win.json\ (not \RELEASES.win.json\)

Also removes the temporary diagnostic listing step.