### PR TITLE
fix: work entry dialog crash, UX improvements (#44)

### DIFF
--- a/src/WorkTracking.UI/App.xaml.cs
+++ b/src/WorkTracking.UI/App.xaml.cs
@@ -33,11 +33,9 @@ public partial class App : Application
 
         DispatcherUnhandledException += (_, e) =>
         {
-            Log.Fatal(e.Exception, "Unhandled UI thread exception");
-            Log.CloseAndFlush();
-            ShowCrashDialog(e.Exception);
+            Log.Error(e.Exception, "Unhandled UI thread exception");
             e.Handled = true;
-            Shutdown(1);
+            ShowErrorDialog(e.Exception);
         };
 
         AppDomain.CurrentDomain.UnhandledException += (_, e) =>
@@ -46,7 +44,7 @@ public partial class App : Application
             Log.Fatal(ex, "Unhandled AppDomain exception (terminating: {IsTerminating})", e.IsTerminating);
             Log.CloseAndFlush();
             if (e.IsTerminating)
-                ShowCrashDialog(ex);
+                ShowErrorDialog(ex);
         };
 
         TaskScheduler.UnobservedTaskException += (_, e) =>
@@ -94,7 +92,7 @@ public partial class App : Application
         {
             Log.Fatal(ex, "Fatal error during startup");
             Log.CloseAndFlush();
-            ShowCrashDialog(ex);
+            ShowErrorDialog(ex);
             Shutdown(1);
         }
     }
@@ -107,7 +105,7 @@ public partial class App : Application
         base.OnExit(e);
     }
 
-    private static void ShowCrashDialog(Exception? ex)
+    private static void ShowErrorDialog(Exception? ex)
     {
         var logFolder = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),

--- a/src/WorkTracking.UI/Services/DialogService.cs
+++ b/src/WorkTracking.UI/Services/DialogService.cs
@@ -5,6 +5,18 @@ namespace WorkTracking.UI.Services;
 
 public class DialogService : IDialogService
 {
+    private static Window? GetOwnerWindow()
+    {
+        // Walk windows from the top to find a visible, non-dialog window to use as owner.
+        // Avoids "Cannot set Owner to itself" when a dialog window is currently active.
+        var active = Application.Current.Windows
+            .OfType<Window>()
+            .FirstOrDefault(w => w.IsActive && w is not Views.WorkEntryDialog
+                                            and not Views.InvoicePrepDialog
+                                            and not Views.AddClientDialog);
+        return active ?? Application.Current.Windows.OfType<MainWindow>().FirstOrDefault();
+    }
+
     public void ShowError(string message, string title = "Error")
         => MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Error);
 
@@ -25,30 +37,21 @@ public class DialogService : IDialogService
 
     public bool ShowInvoicePrepDialog(ViewModels.InvoicePrepViewModel vm)
     {
-        var dialog = new Views.InvoicePrepDialog(vm)
-        {
-            Owner = Application.Current.MainWindow
-        };
+        var dialog = new Views.InvoicePrepDialog(vm) { Owner = GetOwnerWindow() };
         dialog.ShowDialog();
         return vm.Confirmed;
     }
 
     public bool ShowAddClientDialog(ViewModels.AddClientViewModel vm)
     {
-        var dialog = new Views.AddClientDialog(vm)
-        {
-            Owner = Application.Current.MainWindow
-        };
+        var dialog = new Views.AddClientDialog(vm) { Owner = GetOwnerWindow() };
         dialog.ShowDialog();
         return vm.Confirmed;
     }
 
     public bool ShowWorkEntryDialog(ViewModels.WorkEntryDialogViewModel vm)
     {
-        var dialog = new Views.WorkEntryDialog(vm)
-        {
-            Owner = Application.Current.MainWindow
-        };
+        var dialog = new Views.WorkEntryDialog(vm) { Owner = GetOwnerWindow() };
         dialog.ShowDialog();
         return vm.Confirmed;
     }

--- a/src/WorkTracking.UI/ViewModels/TimesheetViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/TimesheetViewModel.cs
@@ -68,6 +68,8 @@ public class TimesheetViewModel(
         {
             SetField(ref _selectedEntry, value);
             OnPropertyChanged(nameof(HasSelectedEntry));
+            OnPropertyChanged(nameof(CanEditSelectedEntry));
+            OnPropertyChanged(nameof(EditOrViewButtonLabel));
             OnPropertyChanged(nameof(RenderedNotesHtml));
         }
     }
@@ -298,14 +300,22 @@ public class TimesheetViewModel(
         }
     });
 
-    public ICommand EditEntryCommand => new RelayCommand(
+    public bool CanEditSelectedEntry => _selectedEntry is not null && !_selectedEntry.IsInvoiced;
+    public string EditOrViewButtonLabel => _selectedEntry?.IsInvoiced == true ? "View" : "Edit";
+
+    public ICommand EditOrViewEntryCommand => new RelayCommand(
         async _ =>
         {
             if (_selectedEntry is null) return;
             var enabledCategories = CategoriesWithAll.Skip(1).ToList();
-            var vm = new WorkEntryDialogViewModel(enabledCategories, _selectedEntry.Entry);
+            var isReadOnly = _selectedEntry.IsInvoiced;
+            var vm = new WorkEntryDialogViewModel(enabledCategories, _selectedEntry.Entry, isReadOnly: isReadOnly);
+            if (isReadOnly)
+            {
+                dialogService.ShowWorkEntryDialog(vm);
+                return;
+            }
             if (!dialogService.ShowWorkEntryDialog(vm)) return;
-
             try
             {
                 var entry = _selectedEntry.Entry;
@@ -322,7 +332,7 @@ public class TimesheetViewModel(
                 dialogService.ShowError($"Failed to update entry: {ex.Message}");
             }
         },
-        _ => _selectedEntry is not null && !_selectedEntry.IsInvoiced);
+        _ => _selectedEntry is not null);
 
     public ICommand DeleteEntryCommand => new RelayCommand(
         async _ =>

--- a/src/WorkTracking.UI/Views/TimesheetView.xaml
+++ b/src/WorkTracking.UI/Views/TimesheetView.xaml
@@ -139,8 +139,8 @@
                                 <Setter Property="Foreground" Value="Gray"/>
                             </DataTrigger>
                             <Trigger Property="IsSelected" Value="True">
-                                <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
-                                <Setter Property="Foreground" Value="White"/>
+                                <Setter Property="Background" Value="{DynamicResource ListSelectedBrush}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
                             </Trigger>
                         </Style.Triggers>
                     </Style>

--- a/src/WorkTracking.UI/Views/TimesheetView.xaml
+++ b/src/WorkTracking.UI/Views/TimesheetView.xaml
@@ -133,10 +133,15 @@
                 </DataGrid.InputBindings>
                 <DataGrid.RowStyle>
                     <Style TargetType="DataGridRow">
+                        <EventSetter Event="MouseDoubleClick" Handler="OnRowDoubleClick"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding IsInvoiced}" Value="True">
                                 <Setter Property="Foreground" Value="Gray"/>
                             </DataTrigger>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+                                <Setter Property="Foreground" Value="White"/>
+                            </Trigger>
                         </Style.Triggers>
                     </Style>
                 </DataGrid.RowStyle>

--- a/src/WorkTracking.UI/Views/TimesheetView.xaml
+++ b/src/WorkTracking.UI/Views/TimesheetView.xaml
@@ -80,12 +80,12 @@
                         <TextBlock Text="Add Entry" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
-                <Button Command="{Binding EditEntryCommand}"
+                <Button Command="{Binding EditOrViewEntryCommand}"
                         Style="{StaticResource ToolbarButton}" Margin="0,0,4,0">
                     <StackPanel Orientation="Horizontal">
                         <Path Data="{StaticResource IconEdit}" Fill="{DynamicResource TextPrimaryBrush}"
                               Width="12" Height="12" Stretch="Uniform" Margin="0,0,4,0" VerticalAlignment="Center"/>
-                        <TextBlock Text="Edit" VerticalAlignment="Center"/>
+                        <TextBlock Text="{Binding EditOrViewButtonLabel}" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
                 <Button Command="{Binding DeleteEntryCommand}"
@@ -94,14 +94,6 @@
                         <Path Data="{StaticResource IconDelete}" Fill="{DynamicResource TextPrimaryBrush}"
                               Width="12" Height="12" Stretch="Uniform" Margin="0,0,4,0" VerticalAlignment="Center"/>
                         <TextBlock Text="Delete" VerticalAlignment="Center"/>
-                    </StackPanel>
-                </Button>
-                <Button Command="{Binding ViewEntryCommand}"
-                        Style="{StaticResource ToolbarButton}">
-                    <StackPanel Orientation="Horizontal">
-                        <Path Data="{StaticResource IconView}" Fill="{DynamicResource TextPrimaryBrush}"
-                              Width="12" Height="12" Stretch="Uniform" Margin="0,0,4,0" VerticalAlignment="Center"/>
-                        <TextBlock Text="View" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
 
@@ -136,7 +128,7 @@
                       BorderThickness="0">
                 <DataGrid.InputBindings>
                     <KeyBinding Key="Insert" Command="{Binding AddEntryCommand}"/>
-                    <KeyBinding Key="F2" Command="{Binding EditEntryCommand}"/>
+                    <KeyBinding Key="F2" Command="{Binding EditOrViewEntryCommand}"/>
                     <KeyBinding Key="Delete" Command="{Binding DeleteEntryCommand}"/>
                 </DataGrid.InputBindings>
                 <DataGrid.RowStyle>

--- a/src/WorkTracking.UI/Views/TimesheetView.xaml.cs
+++ b/src/WorkTracking.UI/Views/TimesheetView.xaml.cs
@@ -39,4 +39,10 @@ public partial class TimesheetView : UserControl
         var html = _vm?.RenderedNotesHtml ?? "<html><body></body></html>";
         NotesWebBrowser.NavigateToString(html);
     }
+
+    private void OnRowDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+    {
+        if (_vm?.EditOrViewEntryCommand.CanExecute(null) == true)
+            _vm.EditOrViewEntryCommand.Execute(null);
+    }
 }

--- a/tests/WorkTracking.Tests/UI/TimesheetViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/TimesheetViewModelTests.cs
@@ -296,23 +296,23 @@ public class TimesheetViewModelInvoicedLockTests
     };
 
     [Fact]
-    public async Task EditEntryCommand_WhenEntryIsInvoiced_CanExecuteReturnsFalse()
+    public async Task EditOrViewEntryCommand_WhenEntryIsInvoiced_CanExecuteReturnsTrue()
     {
         var (vm, _, _) = MakeVm();
         await vm.LoadAsync(1, 100m, null);
         vm.SelectedEntry = new WorkEntryRowViewModel(MakeEntry(1, invoiced: true), null);
 
-        vm.EditEntryCommand.CanExecute(null).Should().BeFalse();
+        vm.EditOrViewEntryCommand.CanExecute(null).Should().BeTrue();
     }
 
     [Fact]
-    public async Task EditEntryCommand_WhenEntryIsUninvoiced_CanExecuteReturnsTrue()
+    public async Task EditOrViewEntryCommand_WhenEntryIsUninvoiced_CanExecuteReturnsTrue()
     {
         var (vm, _, _) = MakeVm();
         await vm.LoadAsync(1, 100m, null);
         vm.SelectedEntry = new WorkEntryRowViewModel(MakeEntry(1, invoiced: false), null);
 
-        vm.EditEntryCommand.CanExecute(null).Should().BeTrue();
+        vm.EditOrViewEntryCommand.CanExecute(null).Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
Closes #44

## Changes

### Bug fixes
- **Dialog Owner crash** — \DialogService\ now walks \Application.Current.Windows\ to find a safe parent window rather than blindly using \MainWindow\ (which caused \Cannot set Owner to itself\ when a dialog was already active)
- **App no longer closes on non-fatal errors** — \DispatcherUnhandledException\ logs and shows a dialog but does not call \Shutdown\

### UX improvements
- **Edit/View consolidated** — \EditEntryCommand\ + \ViewEntryCommand\ replaced by a single \EditOrViewEntryCommand\; button label shows **Edit** for uninvoiced entries and **View** for invoiced entries; dialog opens in read-only mode for invoiced entries
- **Double-click to open** — double-clicking any row opens the edit/view dialog
- **Row selection highlight** — selected row is now highlighted using \AccentBrush\
- **View button removed** — redundant standalone View toolbar button removed

### Tests
- Updated \TimesheetViewModelTests\ to reflect new \EditOrViewEntryCommand\ semantics (invoiced entries can now be opened in view mode, so CanExecute returns true in both cases)