### PR TITLE
chore: SHA-256 checksum generation and release verification docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,11 +58,22 @@ jobs:
           --icon src/WorkTracking.UI/app.ico
           --outputDir installer/
 
+      - name: Generate checksums
+        shell: pwsh
+        run: |
+          $files = @("installer/Billable-win-Setup.exe", "installer/releases.win.json")
+          $lines = foreach ($f in $files) {
+            $hash = (Get-FileHash $f -Algorithm SHA256).Hash.ToLower()
+            "$hash  $(Split-Path $f -Leaf)"
+          }
+          $lines | Out-File -FilePath installer/SHA256SUMS.txt -Encoding utf8
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             installer/Billable-win-Setup.exe
             installer/releases.win.json
+            installer/SHA256SUMS.txt
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/docs/running-and-testing.md
+++ b/docs/running-and-testing.md
@@ -116,32 +116,3 @@ dotnet build WorkTracking.slnx
 
 Expected output: `Build succeeded` with no errors or warnings.
 
----
-
-## Downloading and verifying a release
-
-Official releases are published at [github.com/codebureau/billable/releases](https://github.com/codebureau/billable/releases).
-
-Each release includes three files:
-
-| File | Purpose |
-|---|---|
-| `Billable-win-Setup.exe` | Installer — run this to install or update |
-| `releases.win.json` | Velopack update manifest |
-| `SHA256SUMS.txt` | SHA-256 checksums for the two files above |
-
-### Verifying the download (PowerShell)
-
-After downloading `Billable-win-Setup.exe`, open PowerShell in the same folder and run:
-
-```powershell
-(Get-FileHash .\Billable-win-Setup.exe -Algorithm SHA256).Hash.ToLower()
-```
-
-Compare the output against the hash for `Billable-win-Setup.exe` in `SHA256SUMS.txt`. They must match exactly.
-
-### Windows Defender / SmartScreen warning
-
-Until the installer is Authenticode-signed (tracked in [#46](https://github.com/codebureau/billable/issues/46)), Windows may show an *"Unknown publisher"* SmartScreen prompt or flag the file as suspicious. This is a false positive caused by the installer having no code-signing reputation.
-
-**Workaround:** verify the SHA-256 checksum as above to confirm the file is the authentic release, then choose *"Run anyway"* in the SmartScreen dialog.

--- a/docs/running-and-testing.md
+++ b/docs/running-and-testing.md
@@ -115,3 +115,33 @@ dotnet build WorkTracking.slnx
 ```
 
 Expected output: `Build succeeded` with no errors or warnings.
+
+---
+
+## Downloading and verifying a release
+
+Official releases are published at [github.com/codebureau/billable/releases](https://github.com/codebureau/billable/releases).
+
+Each release includes three files:
+
+| File | Purpose |
+|---|---|
+| `Billable-win-Setup.exe` | Installer — run this to install or update |
+| `releases.win.json` | Velopack update manifest |
+| `SHA256SUMS.txt` | SHA-256 checksums for the two files above |
+
+### Verifying the download (PowerShell)
+
+After downloading `Billable-win-Setup.exe`, open PowerShell in the same folder and run:
+
+```powershell
+(Get-FileHash .\Billable-win-Setup.exe -Algorithm SHA256).Hash.ToLower()
+```
+
+Compare the output against the hash for `Billable-win-Setup.exe` in `SHA256SUMS.txt`. They must match exactly.
+
+### Windows Defender / SmartScreen warning
+
+Until the installer is Authenticode-signed (tracked in [#46](https://github.com/codebureau/billable/issues/46)), Windows may show an *"Unknown publisher"* SmartScreen prompt or flag the file as suspicious. This is a false positive caused by the installer having no code-signing reputation.
+
+**Workaround:** verify the SHA-256 checksum as above to confirm the file is the authentic release, then choose *"Run anyway"* in the SmartScreen dialog.

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -3,16 +3,34 @@
 ## Installation
 
 1. Go to the [Releases page](https://github.com/codebureau/billable/releases)
-2. Download `billable.exe` from the latest release
-3. Place it anywhere convenient -- your Desktop, `C:\Tools\`, wherever you prefer
-4. Double-click to launch
+2. Download `Billable-win-Setup.exe` from the latest release
+3. Run the installer — it will install Billable and create a Start Menu shortcut
+4. Launch Billable from the Start Menu
 
-No installer, no .NET prerequisite -- everything is bundled inside the single file.
+No .NET prerequisite — everything is bundled inside the installer.
 
-!!! warning "Windows SmartScreen warning"
-    Because the executable is not yet code-signed, Windows may show a SmartScreen
-    prompt on first run. This is expected.
-    Click **More info**, then **Run anyway** to proceed. This prompt only appears once.
+!!! warning "Windows SmartScreen / Defender warning"
+    Because the installer is not yet code-signed, Windows may show a SmartScreen
+    prompt or flag the file as suspicious. This is a false positive caused by the
+    installer having no code-signing reputation.
+
+    Before running, verify the download using the `SHA256SUMS.txt` file attached to
+    the release (see [Verifying your download](#verifying-your-download) below).
+    Then click **More info → Run anyway** in the SmartScreen dialog.
+
+---
+
+## Verifying your download
+
+Each release includes a `SHA256SUMS.txt` file on the [Releases page](https://github.com/codebureau/billable/releases). Use it to confirm your download hasn't been tampered with.
+
+Open PowerShell in the folder where you saved the installer and run:
+
+```powershell
+(Get-FileHash .\Billable-win-Setup.exe -Algorithm SHA256).Hash.ToLower()
+```
+
+Compare the output against the hash listed for `Billable-win-Setup.exe` in `SHA256SUMS.txt`. They must match exactly.
 
 ---
 


### PR DESCRIPTION
Closes #47

## Changes

- **\.github/workflows/release.yml\** — adds a \Generate checksums\ step after \Pack installer\ that produces \SHA256SUMS.txt\ (one \<hash>  <filename>\ line per release artifact); attaches it to the GitHub Release alongside the installer
- **\docs/running-and-testing.md\** — adds a *Downloading and verifying a release* section: release file table, PowerShell verification command, and a note on the SmartScreen/Defender false positive with a link to #46