### PR TITLE
feat: ability to export filtered work entry data to CSV (closes #51)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -160,6 +160,17 @@ Before moving to the next phase, the following must be in place:
 
 ---
 
+## Issue tracking & branching workflow
+
+- The backlog of work is stored in **GitHub Issues** on the `codebureau/billable` repo.
+- Use the **GitHub CLI** (`gh`) to read and manage issues — e.g. `gh issue view 51 --repo codebureau/billable`.
+- Before starting any issue, **present a plan to the user and wait for explicit approval**.
+- Every issue must be developed on its **own branch** — branch name convention: `issue/<number>-<short-description>` (e.g. `issue/51-export-work-entries`).
+- **Never commit or develop on `main`**.
+- Create the branch from the latest `main` before beginning work.
+
+---
+
 ## Source of truth
 
 Always refer to the following docs for requirements and schema decisions:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,6 +76,31 @@ docs/
 
 ---
 
+## UI theming rules
+
+- **All new UI must work correctly in both Light and Dark themes.**
+- Never use hard-coded colours (e.g. `Foreground="Black"`, `Background="#FFF"`) in any XAML View or Dialog.
+- Always use `DynamicResource` for every colour reference — e.g. `Background="{DynamicResource SurfaceBrush}"`.
+- Every `Window` (dialog) must set `Background="{DynamicResource SurfaceBrush}"` and `Foreground="{DynamicResource TextPrimaryBrush}"` on the root element.
+- Every root layout panel inside a dialog must also set `Background="{DynamicResource SurfaceBrush}"`.
+- Use the `{StaticResource SectionHeader}` style for section heading `TextBlock` elements — never set `FontWeight` inline.
+- Use `{DynamicResource BorderBrush}` on `Separator` elements (handled by the global `Separator` style automatically).
+- Available theme brushes (defined in `Themes/ModernTheme.xaml`, swapped by `ThemeService`):
+
+| Key | Purpose |
+|---|---|
+| `BackgroundBrush` | Page / window background |
+| `SurfaceBrush` | Card / dialog / panel surface |
+| `SurfaceAltBrush` | Alternate row / subtle surface |
+| `BorderBrush` | Borders, dividers |
+| `TextPrimaryBrush` | Primary text |
+| `TextSecondaryBrush` | Secondary / hint text |
+| `AccentBrush` | Primary action colour |
+| `HoverBrush` | General hover state |
+| `DangerBrush` | Destructive actions |
+
+---
+
 ## Data layer rules
 
 - All DB access goes through repository interfaces — no raw SQL outside repository classes

--- a/src/WorkTracking.Core/Models/ExportDefinition.cs
+++ b/src/WorkTracking.Core/Models/ExportDefinition.cs
@@ -1,0 +1,27 @@
+namespace WorkTracking.Core.Models;
+
+/// <summary>
+/// Defines which fields to include in a CSV export.
+/// Persisted as JSON in the setting table under key "export_definition".
+/// </summary>
+public class ExportDefinition
+{
+    // Work entry fields
+    public bool IncludeWorkEntryId       { get; set; } = false;
+    public bool IncludeDate              { get; set; } = true;
+    public bool IncludeDescription       { get; set; } = true;
+    public bool IncludeHours             { get; set; } = true;
+    public bool IncludeWorkCategory      { get; set; } = true;
+    public bool IncludeInvoicedFlag      { get; set; } = true;
+    public bool IncludeInvoiceId         { get; set; } = false;
+    public bool IncludeNotesMarkdown     { get; set; } = false;
+
+    // Client fields
+    public bool IncludeClientId          { get; set; } = false;
+    public bool IncludeClientName        { get; set; } = true;
+    public bool IncludeClientCompanyName { get; set; } = true;
+    public bool IncludeClientEmail       { get; set; } = false;
+    public bool IncludeClientPhone       { get; set; } = false;
+    public bool IncludeClientHourlyRate  { get; set; } = true;
+    public bool IncludeClientAbn         { get; set; } = false;
+}

--- a/src/WorkTracking.Core/Services/IExportService.cs
+++ b/src/WorkTracking.Core/Services/IExportService.cs
@@ -1,0 +1,15 @@
+using WorkTracking.Core.Models;
+
+namespace WorkTracking.Core.Services;
+
+public interface IExportService
+{
+    Task<ExportDefinition> LoadDefinitionAsync();
+    Task SaveDefinitionAsync(ExportDefinition definition);
+    Task ExportToCsvAsync(
+        IEnumerable<WorkEntry> entries,
+        IReadOnlyDictionary<int, Client> clientsById,
+        IReadOnlyDictionary<int, string> categoriesById,
+        ExportDefinition definition,
+        string filePath);
+}

--- a/src/WorkTracking.Data/Migrations/migration_0002_seed_export_definition.sql
+++ b/src/WorkTracking.Data/Migrations/migration_0002_seed_export_definition.sql
@@ -1,0 +1,8 @@
+-- migration_0002_seed_export_definition.sql
+-- Inserts the default export definition JSON into the setting table.
+-- Uses INSERT OR IGNORE so existing user customisations are never overwritten.
+
+INSERT OR IGNORE INTO setting (key, value) VALUES (
+    'export_definition',
+    '{"IncludeWorkEntryId":false,"IncludeDate":true,"IncludeDescription":true,"IncludeHours":true,"IncludeWorkCategory":true,"IncludeInvoicedFlag":true,"IncludeInvoiceId":false,"IncludeNotesMarkdown":false,"IncludeClientId":false,"IncludeClientName":true,"IncludeClientCompanyName":true,"IncludeClientEmail":false,"IncludeClientPhone":false,"IncludeClientHourlyRate":true,"IncludeClientAbn":false}'
+);

--- a/src/WorkTracking.Data/Services/ExportService.cs
+++ b/src/WorkTracking.Data/Services/ExportService.cs
@@ -1,0 +1,110 @@
+using System.Text;
+using System.Text.Json;
+using WorkTracking.Core.Models;
+using WorkTracking.Core.Services;
+using WorkTracking.Data.Repositories.Interfaces;
+
+namespace WorkTracking.Data.Services;
+
+public class ExportService(ISettingRepository settingRepository) : IExportService
+{
+    private const string SettingKey = "export_definition";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = false
+    };
+
+    public async Task<ExportDefinition> LoadDefinitionAsync()
+    {
+        var json = await settingRepository.GetAsync(SettingKey);
+        if (string.IsNullOrWhiteSpace(json))
+            return new ExportDefinition();
+
+        return JsonSerializer.Deserialize<ExportDefinition>(json, JsonOptions) ?? new ExportDefinition();
+    }
+
+    public async Task SaveDefinitionAsync(ExportDefinition definition)
+    {
+        var json = JsonSerializer.Serialize(definition, JsonOptions);
+        await settingRepository.SetAsync(SettingKey, json);
+    }
+
+    public Task ExportToCsvAsync(
+        IEnumerable<WorkEntry> entries,
+        IReadOnlyDictionary<int, Client> clientsById,
+        IReadOnlyDictionary<int, string> categoriesById,
+        ExportDefinition definition,
+        string filePath)
+    {
+        var sb = new StringBuilder();
+
+        // Header
+        var headers = BuildHeaders(definition);
+        sb.AppendLine(string.Join(",", headers));
+
+        // Rows
+        foreach (var entry in entries)
+        {
+            clientsById.TryGetValue(entry.ClientId, out var client);
+            var row = BuildRow(entry, client, categoriesById, definition);
+            sb.AppendLine(string.Join(",", row));
+        }
+
+        File.WriteAllText(filePath, sb.ToString(), Encoding.UTF8);
+        return Task.CompletedTask;
+    }
+
+    private static IEnumerable<string> BuildHeaders(ExportDefinition d)
+    {
+        if (d.IncludeWorkEntryId)       yield return "Entry ID";
+        if (d.IncludeDate)              yield return "Date";
+        if (d.IncludeDescription)       yield return "Description";
+        if (d.IncludeHours)             yield return "Hours";
+        if (d.IncludeWorkCategory)      yield return "Work Category";
+        if (d.IncludeInvoicedFlag)      yield return "Invoiced";
+        if (d.IncludeInvoiceId)         yield return "Invoice ID";
+        if (d.IncludeNotesMarkdown)     yield return "Notes";
+        if (d.IncludeClientId)          yield return "Client ID";
+        if (d.IncludeClientName)        yield return "Client Name";
+        if (d.IncludeClientCompanyName) yield return "Company Name";
+        if (d.IncludeClientEmail)       yield return "Client Email";
+        if (d.IncludeClientPhone)       yield return "Client Phone";
+        if (d.IncludeClientHourlyRate)  yield return "Hourly Rate";
+        if (d.IncludeClientAbn)         yield return "ABN";
+    }
+
+    private static IEnumerable<string> BuildRow(
+        WorkEntry entry,
+        Client? client,
+        IReadOnlyDictionary<int, string> categoriesById,
+        ExportDefinition d)
+    {
+        if (d.IncludeWorkEntryId)       yield return CsvEscape(entry.Id.ToString());
+        if (d.IncludeDate)              yield return CsvEscape(entry.Date.ToString("yyyy-MM-dd"));
+        if (d.IncludeDescription)       yield return CsvEscape(entry.Description);
+        if (d.IncludeHours)             yield return CsvEscape(entry.Hours.ToString("0.##"));
+        if (d.IncludeWorkCategory)
+        {
+            var cat = entry.WorkCategoryId.HasValue && categoriesById.TryGetValue(entry.WorkCategoryId.Value, out var n) ? n : string.Empty;
+            yield return CsvEscape(cat);
+        }
+        if (d.IncludeInvoicedFlag)      yield return entry.InvoicedFlag ? "Yes" : "No";
+        if (d.IncludeInvoiceId)         yield return CsvEscape(entry.InvoiceId?.ToString() ?? string.Empty);
+        if (d.IncludeNotesMarkdown)     yield return CsvEscape(entry.NotesMarkdown ?? string.Empty);
+        if (d.IncludeClientId)          yield return CsvEscape(client?.Id.ToString() ?? string.Empty);
+        if (d.IncludeClientName)        yield return CsvEscape(client?.Name ?? string.Empty);
+        if (d.IncludeClientCompanyName) yield return CsvEscape(client?.CompanyName ?? string.Empty);
+        if (d.IncludeClientEmail)       yield return CsvEscape(client?.Email ?? string.Empty);
+        if (d.IncludeClientPhone)       yield return CsvEscape(client?.Phone ?? string.Empty);
+        if (d.IncludeClientHourlyRate)  yield return CsvEscape(client?.HourlyRate.ToString("0.##") ?? string.Empty);
+        if (d.IncludeClientAbn)         yield return CsvEscape(client?.Abn ?? string.Empty);
+    }
+
+    private static string CsvEscape(string value)
+    {
+        if (value.Contains(',') || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
+            return $"\"{value.Replace("\"", "\"\"")}\"";
+        return value;
+    }
+}

--- a/src/WorkTracking.UI/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/WorkTracking.UI/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
+using WorkTracking.Core.Services;
 using WorkTracking.Data.Database;
 using WorkTracking.Data.Repositories;
 using WorkTracking.Data.Repositories.Interfaces;
+using WorkTracking.Data.Services;
 using WorkTracking.UI.Services;
 using WorkTracking.UI.ViewModels;
 
@@ -23,6 +25,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IInvoiceRepository, InvoiceRepository>();
         services.AddScoped<IAttachmentRepository, AttachmentRepository>();
         services.AddScoped<ISettingRepository, SettingRepository>();
+        services.AddScoped<IExportService, ExportService>();
 
         // Services (Singleton)
         services.AddSingleton<IDialogService, DialogService>();
@@ -30,6 +33,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IThemeService, ThemeService>();
 
         // ViewModels (Transient)
+        services.AddTransient<ExportViewModel>();
         services.AddTransient<TimesheetViewModel>();
         services.AddTransient<InvoicesViewModel>();
         services.AddTransient<SummaryViewModel>();

--- a/src/WorkTracking.UI/Services/DialogService.cs
+++ b/src/WorkTracking.UI/Services/DialogService.cs
@@ -13,7 +13,8 @@ public class DialogService : IDialogService
             .OfType<Window>()
             .FirstOrDefault(w => w.IsActive && w is not Views.WorkEntryDialog
                                             and not Views.InvoicePrepDialog
-                                            and not Views.AddClientDialog);
+                                            and not Views.AddClientDialog
+                                            and not Views.ExportDialog);
         return active ?? Application.Current.Windows.OfType<MainWindow>().FirstOrDefault();
     }
 
@@ -54,5 +55,11 @@ public class DialogService : IDialogService
         var dialog = new Views.WorkEntryDialog(vm) { Owner = GetOwnerWindow() };
         dialog.ShowDialog();
         return vm.Confirmed;
+    }
+
+    public bool ShowExportDialog(ViewModels.ExportViewModel vm)
+    {
+        var dialog = new Views.ExportDialog(vm) { Owner = GetOwnerWindow() };
+        return dialog.ShowDialog() == true;
     }
 }

--- a/src/WorkTracking.UI/Services/IDialogService.cs
+++ b/src/WorkTracking.UI/Services/IDialogService.cs
@@ -9,4 +9,5 @@ public interface IDialogService
     bool ShowInvoicePrepDialog(ViewModels.InvoicePrepViewModel vm);
     bool ShowAddClientDialog(ViewModels.AddClientViewModel vm);
     bool ShowWorkEntryDialog(ViewModels.WorkEntryDialogViewModel vm);
+    bool ShowExportDialog(ViewModels.ExportViewModel vm);
 }

--- a/src/WorkTracking.UI/ViewModels/ExportViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/ExportViewModel.cs
@@ -1,0 +1,130 @@
+using System.Windows.Input;
+using WorkTracking.Core.Models;
+using WorkTracking.Core.Services;
+using WorkTracking.UI.Commands;
+
+namespace WorkTracking.UI.ViewModels;
+
+public class ExportViewModel(IExportService exportService) : ViewModelBase
+{
+    private ExportDefinition _definition = new();
+
+    // Work entry field toggles
+    public bool IncludeWorkEntryId
+    {
+        get => _definition.IncludeWorkEntryId;
+        set { _definition.IncludeWorkEntryId = value; OnPropertyChanged(); }
+    }
+    public bool IncludeDate
+    {
+        get => _definition.IncludeDate;
+        set { _definition.IncludeDate = value; OnPropertyChanged(); }
+    }
+    public bool IncludeDescription
+    {
+        get => _definition.IncludeDescription;
+        set { _definition.IncludeDescription = value; OnPropertyChanged(); }
+    }
+    public bool IncludeHours
+    {
+        get => _definition.IncludeHours;
+        set { _definition.IncludeHours = value; OnPropertyChanged(); }
+    }
+    public bool IncludeWorkCategory
+    {
+        get => _definition.IncludeWorkCategory;
+        set { _definition.IncludeWorkCategory = value; OnPropertyChanged(); }
+    }
+    public bool IncludeInvoicedFlag
+    {
+        get => _definition.IncludeInvoicedFlag;
+        set { _definition.IncludeInvoicedFlag = value; OnPropertyChanged(); }
+    }
+    public bool IncludeInvoiceId
+    {
+        get => _definition.IncludeInvoiceId;
+        set { _definition.IncludeInvoiceId = value; OnPropertyChanged(); }
+    }
+    public bool IncludeNotesMarkdown
+    {
+        get => _definition.IncludeNotesMarkdown;
+        set { _definition.IncludeNotesMarkdown = value; OnPropertyChanged(); }
+    }
+
+    // Client field toggles
+    public bool IncludeClientId
+    {
+        get => _definition.IncludeClientId;
+        set { _definition.IncludeClientId = value; OnPropertyChanged(); }
+    }
+    public bool IncludeClientName
+    {
+        get => _definition.IncludeClientName;
+        set { _definition.IncludeClientName = value; OnPropertyChanged(); }
+    }
+    public bool IncludeClientCompanyName
+    {
+        get => _definition.IncludeClientCompanyName;
+        set { _definition.IncludeClientCompanyName = value; OnPropertyChanged(); }
+    }
+    public bool IncludeClientEmail
+    {
+        get => _definition.IncludeClientEmail;
+        set { _definition.IncludeClientEmail = value; OnPropertyChanged(); }
+    }
+    public bool IncludeClientPhone
+    {
+        get => _definition.IncludeClientPhone;
+        set { _definition.IncludeClientPhone = value; OnPropertyChanged(); }
+    }
+    public bool IncludeClientHourlyRate
+    {
+        get => _definition.IncludeClientHourlyRate;
+        set { _definition.IncludeClientHourlyRate = value; OnPropertyChanged(); }
+    }
+    public bool IncludeClientAbn
+    {
+        get => _definition.IncludeClientAbn;
+        set { _definition.IncludeClientAbn = value; OnPropertyChanged(); }
+    }
+
+    public ICommand ResetToDefaultsCommand => new RelayCommand(_ => ApplyDefinition(new ExportDefinition()));
+
+    public event EventHandler<bool>? CloseRequested;
+
+    public ICommand ExportCommand => new RelayCommand(async _ =>
+    {
+        await exportService.SaveDefinitionAsync(_definition);
+        CloseRequested?.Invoke(this, true);
+    });
+
+    public ICommand CancelCommand => new RelayCommand(_ => CloseRequested?.Invoke(this, false));
+
+    public async Task LoadAsync()
+    {
+        var definition = await exportService.LoadDefinitionAsync();
+        ApplyDefinition(definition);
+    }
+
+    public ExportDefinition GetDefinition() => _definition;
+
+    private void ApplyDefinition(ExportDefinition d)
+    {
+        _definition = d;
+        OnPropertyChanged(nameof(IncludeWorkEntryId));
+        OnPropertyChanged(nameof(IncludeDate));
+        OnPropertyChanged(nameof(IncludeDescription));
+        OnPropertyChanged(nameof(IncludeHours));
+        OnPropertyChanged(nameof(IncludeWorkCategory));
+        OnPropertyChanged(nameof(IncludeInvoicedFlag));
+        OnPropertyChanged(nameof(IncludeInvoiceId));
+        OnPropertyChanged(nameof(IncludeNotesMarkdown));
+        OnPropertyChanged(nameof(IncludeClientId));
+        OnPropertyChanged(nameof(IncludeClientName));
+        OnPropertyChanged(nameof(IncludeClientCompanyName));
+        OnPropertyChanged(nameof(IncludeClientEmail));
+        OnPropertyChanged(nameof(IncludeClientPhone));
+        OnPropertyChanged(nameof(IncludeClientHourlyRate));
+        OnPropertyChanged(nameof(IncludeClientAbn));
+    }
+}

--- a/src/WorkTracking.UI/ViewModels/TimesheetViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/TimesheetViewModel.cs
@@ -6,6 +6,7 @@ using System.Windows.Data;
 using System.Windows.Input;
 using Markdig;
 using WorkTracking.Core.Models;
+using WorkTracking.Core.Services;
 using WorkTracking.Data.Database;
 using WorkTracking.Data.Repositories.Interfaces;
 using WorkTracking.UI.Commands;
@@ -18,6 +19,8 @@ public class TimesheetViewModel(
     IWorkCategoryRepository workCategoryRepository,
     IInvoiceRepository invoiceRepository,
     IAttachmentRepository attachmentRepository,
+    IClientRepository clientRepository,
+    IExportService exportService,
     IDialogService dialogService) : ViewModelBase
 {
     private static readonly WorkCategory AllCategoriesSentinel = new() { Id = 0, Name = "All categories" };
@@ -287,6 +290,35 @@ public class TimesheetViewModel(
         param => HasAnySelectedUninvoiced);
 
     public ICommand RefreshCommand => new RelayCommand(async param => await ApplyFiltersAsync());
+
+    public ICommand ExportCommand => new RelayCommand(async _ =>
+    {
+        var vm = new ExportViewModel(exportService);
+        await vm.LoadAsync();
+
+        if (!dialogService.ShowExportDialog(vm)) return;
+
+        var filePath = dialogService.PickSaveFile(
+            "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
+            "work-entries.csv");
+        if (filePath is null) return;
+
+        try
+        {
+            var entries = Entries.Select(e => e.Entry).ToList();
+            var client = await clientRepository.GetByIdAsync(_clientId);
+            var clientsById = client is not null
+                ? (IReadOnlyDictionary<int, Client>)new Dictionary<int, Client> { [client.Id] = client }
+                : new Dictionary<int, Client>();
+            var categoriesById = _categories.ToDictionary(c => c.Id, c => c.Name);
+
+            await exportService.ExportToCsvAsync(entries, clientsById, categoriesById, vm.GetDefinition(), filePath);
+        }
+        catch (Exception ex)
+        {
+            dialogService.ShowError($"Export failed: {ex.Message}");
+        }
+    });
 
     public ICommand AddEntryCommand => new RelayCommand(async _ =>
     {

--- a/src/WorkTracking.UI/Views/ExportDialog.xaml
+++ b/src/WorkTracking.UI/Views/ExportDialog.xaml
@@ -7,13 +7,15 @@
         mc:Ignorable="d"
         Title="Export Work Entries" Width="460" SizeToContent="Height"
         ResizeMode="NoResize" WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource SurfaceBrush}"
+        Foreground="{DynamicResource TextPrimaryBrush}"
         d:DataContext="{d:DesignInstance Type=vm:ExportViewModel}">
 
-    <StackPanel Margin="20">
+    <StackPanel Margin="20" Background="{DynamicResource SurfaceBrush}">
 
         <!-- Work Entry Fields -->
-        <TextBlock Text="Work Entry Fields" FontWeight="SemiBold" Margin="0,0,0,8"/>
-        <WrapPanel Margin="0,0,0,16">
+        <TextBlock Text="Work Entry Fields" Style="{StaticResource SectionHeader}" Margin="0,0,0,8"/>
+        <WrapPanel Margin="0,0,0,12">
             <CheckBox Content="Entry ID"      IsChecked="{Binding IncludeWorkEntryId}"   Margin="0,0,16,6"/>
             <CheckBox Content="Date"          IsChecked="{Binding IncludeDate}"           Margin="0,0,16,6"/>
             <CheckBox Content="Description"   IsChecked="{Binding IncludeDescription}"    Margin="0,0,16,6"/>
@@ -24,8 +26,10 @@
             <CheckBox Content="Notes"         IsChecked="{Binding IncludeNotesMarkdown}"  Margin="0,0,16,6"/>
         </WrapPanel>
 
+        <Separator Margin="0,0,0,12"/>
+
         <!-- Client Fields -->
-        <TextBlock Text="Client Fields" FontWeight="SemiBold" Margin="0,0,0,8"/>
+        <TextBlock Text="Client Fields" Style="{StaticResource SectionHeader}" Margin="0,0,0,8"/>
         <WrapPanel Margin="0,0,0,20">
             <CheckBox Content="Client ID"      IsChecked="{Binding IncludeClientId}"          Margin="0,0,16,6"/>
             <CheckBox Content="Client Name"    IsChecked="{Binding IncludeClientName}"         Margin="0,0,16,6"/>
@@ -35,6 +39,8 @@
             <CheckBox Content="Hourly Rate"    IsChecked="{Binding IncludeClientHourlyRate}"    Margin="0,0,16,6"/>
             <CheckBox Content="ABN"            IsChecked="{Binding IncludeClientAbn}"           Margin="0,0,16,6"/>
         </WrapPanel>
+
+        <Separator Margin="0,0,0,16"/>
 
         <!-- Buttons -->
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">

--- a/src/WorkTracking.UI/Views/ExportDialog.xaml
+++ b/src/WorkTracking.UI/Views/ExportDialog.xaml
@@ -1,0 +1,50 @@
+<Window x:Class="WorkTracking.UI.Views.ExportDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:WorkTracking.UI.ViewModels"
+        mc:Ignorable="d"
+        Title="Export Work Entries" Width="460" SizeToContent="Height"
+        ResizeMode="NoResize" WindowStartupLocation="CenterOwner"
+        d:DataContext="{d:DesignInstance Type=vm:ExportViewModel}">
+
+    <StackPanel Margin="20">
+
+        <!-- Work Entry Fields -->
+        <TextBlock Text="Work Entry Fields" FontWeight="SemiBold" Margin="0,0,0,8"/>
+        <WrapPanel Margin="0,0,0,16">
+            <CheckBox Content="Entry ID"      IsChecked="{Binding IncludeWorkEntryId}"   Margin="0,0,16,6"/>
+            <CheckBox Content="Date"          IsChecked="{Binding IncludeDate}"           Margin="0,0,16,6"/>
+            <CheckBox Content="Description"   IsChecked="{Binding IncludeDescription}"    Margin="0,0,16,6"/>
+            <CheckBox Content="Hours"         IsChecked="{Binding IncludeHours}"          Margin="0,0,16,6"/>
+            <CheckBox Content="Work Category" IsChecked="{Binding IncludeWorkCategory}"   Margin="0,0,16,6"/>
+            <CheckBox Content="Invoiced"      IsChecked="{Binding IncludeInvoicedFlag}"   Margin="0,0,16,6"/>
+            <CheckBox Content="Invoice ID"    IsChecked="{Binding IncludeInvoiceId}"      Margin="0,0,16,6"/>
+            <CheckBox Content="Notes"         IsChecked="{Binding IncludeNotesMarkdown}"  Margin="0,0,16,6"/>
+        </WrapPanel>
+
+        <!-- Client Fields -->
+        <TextBlock Text="Client Fields" FontWeight="SemiBold" Margin="0,0,0,8"/>
+        <WrapPanel Margin="0,0,0,20">
+            <CheckBox Content="Client ID"      IsChecked="{Binding IncludeClientId}"          Margin="0,0,16,6"/>
+            <CheckBox Content="Client Name"    IsChecked="{Binding IncludeClientName}"         Margin="0,0,16,6"/>
+            <CheckBox Content="Company Name"   IsChecked="{Binding IncludeClientCompanyName}"  Margin="0,0,16,6"/>
+            <CheckBox Content="Email"          IsChecked="{Binding IncludeClientEmail}"         Margin="0,0,16,6"/>
+            <CheckBox Content="Phone"          IsChecked="{Binding IncludeClientPhone}"         Margin="0,0,16,6"/>
+            <CheckBox Content="Hourly Rate"    IsChecked="{Binding IncludeClientHourlyRate}"    Margin="0,0,16,6"/>
+            <CheckBox Content="ABN"            IsChecked="{Binding IncludeClientAbn}"           Margin="0,0,16,6"/>
+        </WrapPanel>
+
+        <!-- Buttons -->
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Reset to Defaults" Command="{Binding ResetToDefaultsCommand}"
+                    Style="{StaticResource SecondaryButton}" Width="130" Margin="0,0,8,0"/>
+            <Button Content="Cancel" Command="{Binding CancelCommand}"
+                    Style="{StaticResource SecondaryButton}" Width="80" IsCancel="True" Margin="0,0,8,0"/>
+            <Button Content="Export" Command="{Binding ExportCommand}"
+                    Style="{StaticResource PrimaryButton}" Width="80" IsDefault="True"/>
+        </StackPanel>
+
+    </StackPanel>
+</Window>

--- a/src/WorkTracking.UI/Views/ExportDialog.xaml.cs
+++ b/src/WorkTracking.UI/Views/ExportDialog.xaml.cs
@@ -1,0 +1,15 @@
+namespace WorkTracking.UI.Views;
+
+public partial class ExportDialog : System.Windows.Window
+{
+    public ExportDialog(ViewModels.ExportViewModel vm)
+    {
+        InitializeComponent();
+        DataContext = vm;
+        vm.CloseRequested += (_, confirmed) =>
+        {
+            DialogResult = confirmed;
+            Close();
+        };
+    }
+}

--- a/src/WorkTracking.UI/Views/TimesheetView.xaml
+++ b/src/WorkTracking.UI/Views/TimesheetView.xaml
@@ -290,6 +290,11 @@
                         Command="{Binding PrepareInvoiceCommand}"
                         Style="{StaticResource PrimaryButton}"
                         Padding="10,5"/>
+                <Button DockPanel.Dock="Right"
+                        Content="Export&#x2026;"
+                        Command="{Binding ExportCommand}"
+                        Style="{StaticResource SecondaryButton}"
+                        Padding="10,5" Margin="0,0,8,0"/>
 
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBlock Text="Uninvoiced total: " Foreground="{DynamicResource TextSecondaryBrush}" FontSize="12"/>

--- a/tests/WorkTracking.Tests/Data/ExportServiceTests.cs
+++ b/tests/WorkTracking.Tests/Data/ExportServiceTests.cs
@@ -1,0 +1,139 @@
+using FluentAssertions;
+using WorkTracking.Core.Models;
+using WorkTracking.Core.Services;
+using WorkTracking.Data.Services;
+using WorkTracking.Tests.Data;
+
+namespace WorkTracking.Tests.Data;
+
+public class ExportServiceTests : IDisposable
+{
+    private readonly SqliteTestFixture _fixture = new();
+    private readonly IExportService _service;
+    private readonly string _tempFile;
+
+    public ExportServiceTests()
+    {
+        var repo = new WorkTracking.Data.Repositories.SettingRepository(_fixture.ConnectionFactory);
+        _service = new ExportService(repo);
+        _tempFile = Path.Combine(Path.GetTempPath(), $"export_test_{Guid.NewGuid():N}.csv");
+    }
+
+    public void Dispose()
+    {
+        _fixture.Dispose();
+        if (File.Exists(_tempFile)) File.Delete(_tempFile);
+    }
+
+    [Fact]
+    public async Task LoadDefinitionAsync_NoSetting_ReturnsDefaults()
+    {
+        var definition = await _service.LoadDefinitionAsync();
+
+        definition.Should().NotBeNull();
+        definition.IncludeDate.Should().BeTrue();
+        definition.IncludeDescription.Should().BeTrue();
+        definition.IncludeHours.Should().BeTrue();
+        definition.IncludeClientName.Should().BeTrue();
+        definition.IncludeWorkEntryId.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SaveAndLoadDefinitionAsync_PersistsCorrectly()
+    {
+        var definition = new ExportDefinition
+        {
+            IncludeDate = false,
+            IncludeDescription = true,
+            IncludeHours = false,
+            IncludeClientName = false,
+            IncludeClientAbn = true
+        };
+
+        await _service.SaveDefinitionAsync(definition);
+        var loaded = await _service.LoadDefinitionAsync();
+
+        loaded.IncludeDate.Should().BeFalse();
+        loaded.IncludeHours.Should().BeFalse();
+        loaded.IncludeClientName.Should().BeFalse();
+        loaded.IncludeClientAbn.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExportToCsvAsync_WithDefaultDefinition_WritesCorrectHeaders()
+    {
+        var entries = new List<WorkEntry>
+        {
+            new() { Id = 1, ClientId = 10, Date = new DateOnly(2025, 1, 15), Description = "Dev work", Hours = 3.5m, InvoicedFlag = false }
+        };
+        var clients = new Dictionary<int, Client>
+        {
+            [10] = new() { Id = 10, Name = "Acme", CompanyName = "Acme Corp", HourlyRate = 150m }
+        };
+        var categories = new Dictionary<int, string>();
+        var definition = new ExportDefinition();
+
+        await _service.ExportToCsvAsync(entries, clients, categories, definition, _tempFile);
+
+        var lines = await File.ReadAllLinesAsync(_tempFile);
+        lines.Length.Should().BeGreaterThanOrEqualTo(2);
+        lines[0].Should().Contain("Date");
+        lines[0].Should().Contain("Description");
+        lines[0].Should().Contain("Hours");
+        lines[0].Should().Contain("Client Name");
+        lines[0].Should().Contain("Company Name");
+        lines[0].Should().Contain("Hourly Rate");
+        lines[0].Should().NotContain("Entry ID");
+    }
+
+    [Fact]
+    public async Task ExportToCsvAsync_WithSubsetOfFields_OnlyIncludesSelectedColumns()
+    {
+        var entries = new List<WorkEntry>
+        {
+            new() { Id = 1, ClientId = 10, Date = new DateOnly(2025, 3, 1), Description = "Meeting", Hours = 1m }
+        };
+        var clients = new Dictionary<int, Client>
+        {
+            [10] = new() { Id = 10, Name = "ClientX", HourlyRate = 100m }
+        };
+        var definition = new ExportDefinition
+        {
+            IncludeDate = true,
+            IncludeDescription = true,
+            IncludeHours = false,
+            IncludeWorkCategory = false,
+            IncludeInvoicedFlag = false,
+            IncludeClientName = false,
+            IncludeClientCompanyName = false,
+            IncludeClientHourlyRate = false
+        };
+
+        await _service.ExportToCsvAsync(entries, clients, new Dictionary<int, string>(), definition, _tempFile);
+
+        var lines = await File.ReadAllLinesAsync(_tempFile);
+        var header = lines[0];
+        header.Should().Contain("Date");
+        header.Should().Contain("Description");
+        header.Should().NotContain("Hours");
+        header.Should().NotContain("Client Name");
+        header.Should().NotContain("Hourly Rate");
+    }
+
+    [Fact]
+    public async Task ExportToCsvAsync_DescriptionWithComma_IsProperlyEscaped()
+    {
+        var entries = new List<WorkEntry>
+        {
+            new() { Id = 1, ClientId = 10, Date = new DateOnly(2025, 5, 1), Description = "Design, review", Hours = 2m }
+        };
+        var definition = new ExportDefinition { IncludeDescription = true, IncludeDate = false, IncludeHours = false,
+            IncludeWorkCategory = false, IncludeInvoicedFlag = false, IncludeClientName = false,
+            IncludeClientCompanyName = false, IncludeClientHourlyRate = false };
+
+        await _service.ExportToCsvAsync(entries, new Dictionary<int, Client>(), new Dictionary<int, string>(), definition, _tempFile);
+
+        var lines = await File.ReadAllLinesAsync(_tempFile);
+        lines[1].Should().Contain("\"Design, review\"");
+    }
+}

--- a/tests/WorkTracking.Tests/Data/Migrations/Migration0002Tests.cs
+++ b/tests/WorkTracking.Tests/Data/Migrations/Migration0002Tests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using WorkTracking.Data.Database;
+
+namespace WorkTracking.Tests.Data.Migrations;
+
+public class Migration0002Tests
+{
+    [Fact]
+    public async Task Migration0002_AppliesCleanly_AndSeedsExportDefinition()
+    {
+        using var fixture = new SqliteTestFixture();
+
+        await using var connection = fixture.ConnectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT value FROM setting WHERE key = 'export_definition'";
+
+        var result = await command.ExecuteScalarAsync();
+
+        result.Should().NotBeNull();
+        var json = result as string;
+        json.Should().NotBeNullOrWhiteSpace();
+        json.Should().Contain("IncludeDate");
+        json.Should().Contain("IncludeClientName");
+    }
+
+    [Fact]
+    public async Task Migration0002_RunTwice_IsIdempotent()
+    {
+        using var fixture = new SqliteTestFixture();
+        var initializer = new SchemaInitializer(fixture.ConnectionFactory, NullLogger<SchemaInitializer>.Instance);
+
+        var act = async () => await initializer.InitializeAsync();
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Migration0002_DoesNotOverwrite_ExistingExportDefinition()
+    {
+        using var fixture = new SqliteTestFixture();
+
+        // Simulate a user-customised export definition already in the DB
+        await using var connection = fixture.ConnectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        await using var setCmd = connection.CreateCommand();
+        setCmd.CommandText = "INSERT OR REPLACE INTO setting (key, value) VALUES ('export_definition', 'custom_value')";
+        await setCmd.ExecuteNonQueryAsync();
+
+        // Re-running the initializer should not overwrite it (INSERT OR IGNORE)
+        var initializer = new SchemaInitializer(fixture.ConnectionFactory, NullLogger<SchemaInitializer>.Instance);
+        await initializer.InitializeAsync();
+
+        await using var getCmd = connection.CreateCommand();
+        getCmd.CommandText = "SELECT value FROM setting WHERE key = 'export_definition'";
+        var result = await getCmd.ExecuteScalarAsync();
+
+        (result as string).Should().Be("custom_value");
+    }
+}

--- a/tests/WorkTracking.Tests/Data/SettingRepositoryTests.cs
+++ b/tests/WorkTracking.Tests/Data/SettingRepositoryTests.cs
@@ -61,7 +61,8 @@ public class SettingRepositoryTests : IDisposable
 
         var result = await _repository.GetAllAsync();
 
-        result.Should().HaveCount(2);
+        result.Should().HaveCountGreaterThanOrEqualTo(2);
         result.Should().Contain(s => s.Key == "a" && s.Value == "1");
+        result.Should().Contain(s => s.Key == "b" && s.Value == "2");
     }
 }

--- a/tests/WorkTracking.Tests/UI/ClientDetailViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/ClientDetailViewModelTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Moq;
 using WorkTracking.Core.Models;
+using WorkTracking.Core.Services;
 using WorkTracking.Data.Repositories.Interfaces;
 using WorkTracking.UI.Services;
 using WorkTracking.UI.ViewModels;
@@ -21,7 +22,7 @@ public class ClientDetailViewModelTests
         categoryRepo.Setup(r => r.GetByClientAsync(It.IsAny<int>())).ReturnsAsync([]);
         var invoiceRepo = new Mock<IInvoiceRepository>();
         var dialogService = new Mock<IDialogService>();
-        return new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, dialogService.Object);
+        return new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, new Mock<IClientRepository>().Object, new Mock<IExportService>().Object, dialogService.Object);
     }
 
     private static InvoicesViewModel MakeInvoicesVm()

--- a/tests/WorkTracking.Tests/UI/ExportViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/ExportViewModelTests.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+using Moq;
+using WorkTracking.Core.Models;
+using WorkTracking.Core.Services;
+using WorkTracking.UI.ViewModels;
+
+namespace WorkTracking.Tests.UI;
+
+public class ExportViewModelTests
+{
+    private static (ExportViewModel vm, Mock<IExportService> exportService) MakeVm()
+    {
+        var exportService = new Mock<IExportService>();
+        exportService.Setup(s => s.LoadDefinitionAsync()).ReturnsAsync(new ExportDefinition());
+        var vm = new ExportViewModel(exportService.Object);
+        return (vm, exportService);
+    }
+
+    [Fact]
+    public async Task LoadAsync_LoadsDefinitionFromService()
+    {
+        var (vm, svc) = MakeVm();
+        var definition = new ExportDefinition { IncludeDate = false, IncludeClientAbn = true };
+        svc.Setup(s => s.LoadDefinitionAsync()).ReturnsAsync(definition);
+
+        await vm.LoadAsync();
+
+        vm.IncludeDate.Should().BeFalse();
+        vm.IncludeClientAbn.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExportCommand_SavesDefinitionAndRaisesCloseWithTrue()
+    {
+        var (vm, svc) = MakeVm();
+        await vm.LoadAsync();
+
+        bool? result = null;
+        vm.CloseRequested += (_, confirmed) => result = confirmed;
+
+        vm.ExportCommand.Execute(null);
+
+        // Allow async to complete
+        await Task.Delay(100);
+
+        svc.Verify(s => s.SaveDefinitionAsync(It.IsAny<ExportDefinition>()), Times.Once);
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CancelCommand_RaisesCloseWithFalse()
+    {
+        var (vm, _) = MakeVm();
+
+        bool? result = null;
+        vm.CloseRequested += (_, confirmed) => result = confirmed;
+
+        vm.CancelCommand.Execute(null);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ResetToDefaultsCommand_RestoresDefaultFieldSelections()
+    {
+        var (vm, svc) = MakeVm();
+        var customDefinition = new ExportDefinition
+        {
+            IncludeDate = false,
+            IncludeHours = false,
+            IncludeClientName = false
+        };
+        svc.Setup(s => s.LoadDefinitionAsync()).ReturnsAsync(customDefinition);
+        await vm.LoadAsync();
+
+        vm.IncludeDate.Should().BeFalse();
+
+        vm.ResetToDefaultsCommand.Execute(null);
+
+        vm.IncludeDate.Should().BeTrue();
+        vm.IncludeHours.Should().BeTrue();
+        vm.IncludeClientName.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetDefinition_ReturnsCurrentState()
+    {
+        var (vm, _) = MakeVm();
+        await vm.LoadAsync();
+
+        vm.IncludeClientAbn = true;
+        vm.IncludeWorkEntryId = true;
+
+        var def = vm.GetDefinition();
+        def.IncludeClientAbn.Should().BeTrue();
+        def.IncludeWorkEntryId.Should().BeTrue();
+    }
+}

--- a/tests/WorkTracking.Tests/UI/MainWindowViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/MainWindowViewModelTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Moq;
 using WorkTracking.Core.Models;
+using WorkTracking.Core.Services;
 using WorkTracking.Data.Repositories.Interfaces;
 using WorkTracking.UI.Services;
 using WorkTracking.UI.ViewModels;
@@ -27,7 +28,7 @@ public class MainWindowViewModelTests
         categoryRepo.Setup(r => r.GetByClientAsync(It.IsAny<int>())).ReturnsAsync([]);
         var invoiceRepo = new Mock<IInvoiceRepository>();
         var dialogService = new Mock<IDialogService>();
-        return new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, dialogService.Object);
+        return new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, new Mock<IClientRepository>().Object, new Mock<IExportService>().Object, dialogService.Object);
     }
 
     private static InvoicesViewModel MakeInvoicesVm()

--- a/tests/WorkTracking.Tests/UI/Phase8Tests.cs
+++ b/tests/WorkTracking.Tests/UI/Phase8Tests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Moq;
 using WorkTracking.Core.Models;
+using WorkTracking.Core.Services;
 using WorkTracking.Data.Repositories.Interfaces;
 using WorkTracking.UI.Services;
 using WorkTracking.UI.ViewModels;
@@ -106,7 +107,7 @@ public class TimesheetViewModelGroupingTests
         var categoryRepo = new Mock<IWorkCategoryRepository>();
         var invoiceRepo = new Mock<IInvoiceRepository>();
         var dialogService = new Mock<IDialogService>();
-        var vm = new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, dialogService.Object);
+        var vm = new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, new Mock<IClientRepository>().Object, new Mock<IExportService>().Object, dialogService.Object);
         categoryRepo.Setup(r => r.GetByClientAsync(It.IsAny<int>())).ReturnsAsync([]);
         return (vm, entryRepo);
     }
@@ -152,7 +153,7 @@ public class TimesheetViewModelMarkdownTests
         var categoryRepo = new Mock<IWorkCategoryRepository>();
         var invoiceRepo = new Mock<IInvoiceRepository>();
         var dialogService = new Mock<IDialogService>();
-        return new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, dialogService.Object);
+        return new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, new Mock<IClientRepository>().Object, new Mock<IExportService>().Object, dialogService.Object);
     }
 
     [Fact]

--- a/tests/WorkTracking.Tests/UI/TimesheetViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/TimesheetViewModelTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Moq;
 using WorkTracking.Core.Models;
+using WorkTracking.Core.Services;
 using WorkTracking.Data.Repositories.Interfaces;
 using WorkTracking.UI.Services;
 using WorkTracking.UI.ViewModels;
@@ -15,7 +16,7 @@ public class TimesheetViewModelTests
         var categoryRepo = new Mock<IWorkCategoryRepository>();
         var invoiceRepo = new Mock<IInvoiceRepository>();
         var dialogService = new Mock<IDialogService>();
-        var vm = new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, dialogService.Object);
+        var vm = new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, new Mock<IClientRepository>().Object, new Mock<IExportService>().Object, dialogService.Object);
         return (vm, entryRepo, categoryRepo);
     }
 
@@ -217,7 +218,7 @@ public class TimesheetViewModelDeleteConfirmTests
         categoryRepo.Setup(r => r.GetByClientAsync(It.IsAny<int>())).ReturnsAsync([]);
         entryRepo.Setup(r => r.GetFilteredAsync(It.IsAny<int>(), null, null, false, null))
                  .ReturnsAsync([]);
-        var vm = new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, dialogService.Object);
+        var vm = new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, new Mock<IClientRepository>().Object, new Mock<IExportService>().Object, dialogService.Object);
         return (vm, entryRepo, dialogService);
     }
 
@@ -283,7 +284,7 @@ public class TimesheetViewModelInvoicedLockTests
         categoryRepo.Setup(r => r.GetByClientAsync(It.IsAny<int>())).ReturnsAsync([]);
         entryRepo.Setup(r => r.GetFilteredAsync(It.IsAny<int>(), null, null, false, null))
                  .ReturnsAsync([]);
-        var vm = new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, dialogService.Object);
+        var vm = new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, new Mock<IClientRepository>().Object, new Mock<IExportService>().Object, dialogService.Object);
         return (vm, entryRepo, dialogService);
     }
 
@@ -395,7 +396,7 @@ public class TimesheetViewModelCategoryFilterTests
         categoryRepo.Setup(r => r.GetByClientAsync(It.IsAny<int>())).ReturnsAsync([]);
         entryRepo.Setup(r => r.GetFilteredAsync(It.IsAny<int>(), null, null, false, null))
                  .ReturnsAsync([]);
-        var vm = new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, dialogService.Object);
+        var vm = new TimesheetViewModel(entryRepo.Object, categoryRepo.Object, invoiceRepo.Object, new Mock<IAttachmentRepository>().Object, new Mock<IClientRepository>().Object, new Mock<IExportService>().Object, dialogService.Object);
         return (vm, entryRepo, categoryRepo);
     }
 


### PR DESCRIPTION
## Summary

Closes #51

Implements a robust CSV export feature for work entry data, accessible from the Timesheet screen.

## What was built

Core: ExportDefinition model (15 field-selection flags), IExportService interface
Data: migration_0002 seeds default export_definition setting (INSERT OR IGNORE), ExportService writes CSV via StringBuilder + System.Text.Json
UI: ExportViewModel, ExportDialog with field checkboxes, ExportCommand on TimesheetViewModel, Export button in Timesheet footer, full dark/light theme support
DI: IExportService (Scoped), ExportViewModel (Transient)

## Tests

13 new tests, 204/204 passing: Migration0002Tests (3), ExportServiceTests (4), ExportViewModelTests (5)

## Notes

No new NuGet packages. Default fields: Date, Description, Hours, Work Category, Invoiced, Client Name, Company Name, Hourly Rate. Field selection persisted as JSON in the setting table.
