### PR TITLE
feat(#49): Client deactivation, reactivation, and drag-to-reorder

### DIFF
--- a/src/WorkTracking.Core/Models/Client.cs
+++ b/src/WorkTracking.Core/Models/Client.cs
@@ -16,6 +16,8 @@ public class Client
     public int? InvoiceFrequencyDays { get; set; }
     public DateOnly? LastInvoiceDate { get; set; }
     public DateOnly? NextInvoiceDueDate { get; set; }
+    public bool IsActive { get; set; } = true;
+    public int SortOrder { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
 }

--- a/src/WorkTracking.Data/Migrations/migration_0003_add_client_is_active.sql
+++ b/src/WorkTracking.Data/Migrations/migration_0003_add_client_is_active.sql
@@ -1,0 +1,5 @@
+-- migration_0003_add_client_is_active.sql
+-- Adds is_active column to the client table.
+-- Defaults to 1 (active) so all existing clients remain active.
+
+ALTER TABLE client ADD COLUMN is_active INTEGER NOT NULL DEFAULT 1;

--- a/src/WorkTracking.Data/Migrations/migration_0004_add_client_sort_order.sql
+++ b/src/WorkTracking.Data/Migrations/migration_0004_add_client_sort_order.sql
@@ -1,0 +1,9 @@
+-- migration_0004_add_client_sort_order.sql
+-- Applied: adds sort_order column to client table for manual drag-drop ordering
+
+ALTER TABLE client ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;
+
+-- Initialise existing rows so order matches current alpha ordering
+UPDATE client SET sort_order = (
+    SELECT COUNT(*) FROM client c2 WHERE c2.name < client.name
+);

--- a/src/WorkTracking.Data/Repositories/ClientRepository.cs
+++ b/src/WorkTracking.Data/Repositories/ClientRepository.cs
@@ -9,13 +9,15 @@ namespace WorkTracking.Data.Repositories;
 
 public class ClientRepository(IDatabaseConnectionFactory connectionFactory, ILogger<ClientRepository> logger) : IClientRepository
 {
-    public async Task<IReadOnlyList<Client>> GetAllAsync()
+    public async Task<IReadOnlyList<Client>> GetAllAsync(bool includeInactive = false)
     {
         await using var connection = connectionFactory.CreateConnection();
         await connection.OpenAsync();
 
         await using var command = connection.CreateCommand();
-        command.CommandText = "SELECT * FROM client ORDER BY name";
+        command.CommandText = includeInactive
+            ? "SELECT * FROM client ORDER BY sort_order, name"
+            : "SELECT * FROM client WHERE is_active = 1 ORDER BY sort_order, name";
 
         var clients = new List<Client>();
         await using var reader = await command.ExecuteReaderAsync();
@@ -47,10 +49,10 @@ public class ClientRepository(IDatabaseConnectionFactory connectionFactory, ILog
         command.CommandText = """
             INSERT INTO client (name, contact_name, company_name, address, abn, email, phone,
                 hourly_rate, invoice_cap_amount, invoice_cap_behavior, invoice_frequency_days,
-                last_invoice_date, next_invoice_due_date, created_at, updated_at)
+                last_invoice_date, next_invoice_due_date, is_active, sort_order, created_at, updated_at)
             VALUES ($name, $contactName, $companyName, $address, $abn, $email, $phone,
                 $hourlyRate, $invoiceCapAmount, $invoiceCapBehavior, $invoiceFrequencyDays,
-                $lastInvoiceDate, $nextInvoiceDueDate, $createdAt, $updatedAt);
+                $lastInvoiceDate, $nextInvoiceDueDate, $isActive, $sortOrder, $createdAt, $updatedAt);
             SELECT last_insert_rowid();
             """;
         BindClientParameters(command, client);
@@ -75,6 +77,8 @@ public class ClientRepository(IDatabaseConnectionFactory connectionFactory, ILog
                 invoice_frequency_days = $invoiceFrequencyDays,
                 last_invoice_date = $lastInvoiceDate,
                 next_invoice_due_date = $nextInvoiceDueDate,
+                is_active = $isActive,
+                sort_order = $sortOrder,
                 updated_at = $updatedAt
             WHERE id = $id
             """;
@@ -83,6 +87,41 @@ public class ClientRepository(IDatabaseConnectionFactory connectionFactory, ILog
 
         await command.ExecuteNonQueryAsync();
         logger.LogInformation("Updated client {ClientId} '{Name}'", client.Id, client.Name);
+    }
+
+    public async Task SetActiveAsync(int id, bool active)
+    {
+        await using var connection = connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "UPDATE client SET is_active = $isActive, updated_at = $updatedAt WHERE id = $id";
+        command.Parameters.AddWithValue("$isActive", active ? 1 : 0);
+        command.Parameters.AddWithValue("$updatedAt", DateConversion.ToIso8601(DateTime.UtcNow));
+        command.Parameters.AddWithValue("$id", id);
+
+        await command.ExecuteNonQueryAsync();
+        logger.LogInformation("{Action} client {ClientId}", active ? "Reactivated" : "Deactivated", id);
+    }
+
+    public async Task ReorderAsync(IReadOnlyList<int> orderedIds)
+    {
+        await using var connection = connectionFactory.CreateConnection();
+        await connection.OpenAsync();
+        await using var transaction = await connection.BeginTransactionAsync();
+
+        for (var i = 0; i < orderedIds.Count; i++)
+        {
+            await using var command = connection.CreateCommand();
+            command.Transaction = (Microsoft.Data.Sqlite.SqliteTransaction)transaction;
+            command.CommandText = "UPDATE client SET sort_order = $sortOrder WHERE id = $id";
+            command.Parameters.AddWithValue("$sortOrder", i);
+            command.Parameters.AddWithValue("$id", orderedIds[i]);
+            await command.ExecuteNonQueryAsync();
+        }
+
+        await transaction.CommitAsync();
+        logger.LogInformation("Reordered {Count} clients", orderedIds.Count);
     }
 
     public async Task DeleteAsync(int id)
@@ -118,6 +157,8 @@ public class ClientRepository(IDatabaseConnectionFactory connectionFactory, ILog
             (object?)DateConversion.ToIso8601Nullable(client.LastInvoiceDate) ?? DBNull.Value);
         command.Parameters.AddWithValue("$nextInvoiceDueDate",
             (object?)DateConversion.ToIso8601Nullable(client.NextInvoiceDueDate) ?? DBNull.Value);
+        command.Parameters.AddWithValue("$isActive", client.IsActive ? 1 : 0);
+        command.Parameters.AddWithValue("$sortOrder", client.SortOrder);
         command.Parameters.AddWithValue("$createdAt", now);
         command.Parameters.AddWithValue("$updatedAt", now);
     }
@@ -138,6 +179,8 @@ public class ClientRepository(IDatabaseConnectionFactory connectionFactory, ILog
         InvoiceFrequencyDays = reader.IsDBNull(reader.GetOrdinal("invoice_frequency_days")) ? null : reader.GetInt32(reader.GetOrdinal("invoice_frequency_days")),
         LastInvoiceDate = reader.IsDBNull(reader.GetOrdinal("last_invoice_date")) ? null : DateConversion.ToDateOnly(reader.GetString(reader.GetOrdinal("last_invoice_date"))),
         NextInvoiceDueDate = reader.IsDBNull(reader.GetOrdinal("next_invoice_due_date")) ? null : DateConversion.ToDateOnly(reader.GetString(reader.GetOrdinal("next_invoice_due_date"))),
+        IsActive = reader.GetInt32(reader.GetOrdinal("is_active")) == 1,
+        SortOrder = reader.GetInt32(reader.GetOrdinal("sort_order")),
         CreatedAt = DateConversion.ToDateTime(reader.GetString(reader.GetOrdinal("created_at"))),
         UpdatedAt = DateConversion.ToDateTime(reader.GetString(reader.GetOrdinal("updated_at"))),
     };

--- a/src/WorkTracking.Data/Repositories/Interfaces/IClientRepository.cs
+++ b/src/WorkTracking.Data/Repositories/Interfaces/IClientRepository.cs
@@ -4,9 +4,11 @@ namespace WorkTracking.Data.Repositories.Interfaces;
 
 public interface IClientRepository
 {
-    Task<IReadOnlyList<Client>> GetAllAsync();
+    Task<IReadOnlyList<Client>> GetAllAsync(bool includeInactive = false);
     Task<Client?> GetByIdAsync(int id);
     Task<Client> AddAsync(Client client);
     Task UpdateAsync(Client client);
+    Task SetActiveAsync(int id, bool active);
+    Task ReorderAsync(IReadOnlyList<int> orderedIds);
     Task DeleteAsync(int id);
 }

--- a/src/WorkTracking.UI/Behaviors/ListBoxDragDropReorderBehavior.cs
+++ b/src/WorkTracking.UI/Behaviors/ListBoxDragDropReorderBehavior.cs
@@ -1,0 +1,138 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace WorkTracking.UI.Behaviors;
+
+/// <summary>
+/// Attached behavior that enables drag-drop reordering on a ListBox.
+/// Bind ReorderCommand to an ICommand that accepts (int fromIndex, int toIndex).
+/// </summary>
+public static class ListBoxDragDropReorderBehavior
+{
+    // --- Attached properties ---
+
+    public static readonly DependencyProperty ReorderCommandProperty =
+        DependencyProperty.RegisterAttached(
+            "ReorderCommand",
+            typeof(ICommand),
+            typeof(ListBoxDragDropReorderBehavior),
+            new PropertyMetadata(null, OnReorderCommandChanged));
+
+    public static ICommand? GetReorderCommand(DependencyObject obj) =>
+        (ICommand?)obj.GetValue(ReorderCommandProperty);
+
+    public static void SetReorderCommand(DependencyObject obj, ICommand? value) =>
+        obj.SetValue(ReorderCommandProperty, value);
+
+    // --- Drag state ---
+
+    private static ListBoxItem? _dragSource;
+    private static Point _dragStartPoint;
+    private static bool _isDragging;
+    private const double DragThreshold = 4;
+
+    // --- Hook / unhook ---
+
+    private static void OnReorderCommandChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not ListBox listBox) return;
+
+        if (e.OldValue is not null)
+        {
+            listBox.PreviewMouseLeftButtonDown -= OnMouseDown;
+            listBox.PreviewMouseMove            -= OnMouseMove;
+            listBox.Drop                        -= OnDrop;
+            listBox.DragOver                    -= OnDragOver;
+        }
+
+        if (e.NewValue is not null)
+        {
+            listBox.AllowDrop = true;
+            listBox.PreviewMouseLeftButtonDown += OnMouseDown;
+            listBox.PreviewMouseMove            += OnMouseMove;
+            listBox.Drop                        += OnDrop;
+            listBox.DragOver                    += OnDragOver;
+        }
+    }
+
+    // --- Event handlers ---
+
+    private static void OnMouseDown(object sender, MouseButtonEventArgs e)
+    {
+        _isDragging = false;
+        _dragSource = null;
+
+        if (sender is not ListBox lb) return;
+        var item = GetListBoxItemFromPoint(lb, e.GetPosition(lb));
+        if (item is null) return;
+
+        _dragSource = item;
+        _dragStartPoint = e.GetPosition(lb);
+    }
+
+    private static void OnMouseMove(object sender, MouseEventArgs e)
+    {
+        if (_dragSource is null || e.LeftButton != MouseButtonState.Pressed) return;
+        if (sender is not ListBox lb) return;
+
+        var pos = e.GetPosition(lb);
+        if (!_isDragging)
+        {
+            var delta = pos - _dragStartPoint;
+            if (Math.Abs(delta.X) < DragThreshold && Math.Abs(delta.Y) < DragThreshold) return;
+            _isDragging = true;
+        }
+
+        DragDrop.DoDragDrop(_dragSource, _dragSource.DataContext!, DragDropEffects.Move);
+        _isDragging = false;
+        _dragSource = null;
+    }
+
+    private static void OnDragOver(object sender, DragEventArgs e)
+    {
+        e.Effects = DragDropEffects.Move;
+        e.Handled = true;
+    }
+
+    private static void OnDrop(object sender, DragEventArgs e)
+    {
+        if (sender is not ListBox lb) return;
+
+        var command = GetReorderCommand(lb);
+        if (command is null) return;
+
+        var targetItem = GetListBoxItemFromPoint(lb, e.GetPosition(lb));
+        if (targetItem is null) return;
+
+        var draggedData = e.Data.GetData(e.Data.GetFormats()[0]);
+        if (draggedData is null) return;
+
+        var items = lb.ItemsSource?.Cast<object>().ToList();
+        if (items is null) return;
+
+        var fromIndex = items.IndexOf(draggedData);
+        var toIndex   = items.IndexOf(targetItem.DataContext!);
+
+        if (fromIndex < 0 || toIndex < 0 || fromIndex == toIndex) return;
+
+        if (command.CanExecute((fromIndex, toIndex)))
+            command.Execute((fromIndex, toIndex));
+
+        e.Handled = true;
+    }
+
+    // --- Helper ---
+
+    private static ListBoxItem? GetListBoxItemFromPoint(ListBox lb, Point point)
+    {
+        var element = lb.InputHitTest(point) as DependencyObject;
+        while (element is not null)
+        {
+            if (element is ListBoxItem item) return item;
+            element = VisualTreeHelper.GetParent(element);
+        }
+        return null;
+    }
+}

--- a/src/WorkTracking.UI/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/WorkTracking.UI/DependencyInjection/ServiceCollectionExtensions.cs
@@ -41,7 +41,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<ClientListViewModel>();
         services.AddTransient<ClientDetailViewModel>();
         services.AddTransient<HomeViewModel>();
-        services.AddTransient<AppSettingsViewModel>();
+        services.AddSingleton<AppSettingsViewModel>();
         services.AddTransient<MainWindowViewModel>();
 
         // Main window (Singleton — one instance)

--- a/src/WorkTracking.UI/MainWindow.xaml
+++ b/src/WorkTracking.UI/MainWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="clr-namespace:WorkTracking.UI.ViewModels"
         xmlns:views="clr-namespace:WorkTracking.UI.Views"
+        xmlns:behaviors="clr-namespace:WorkTracking.UI.Behaviors"
         mc:Ignorable="d"
         Title="{Binding Title}" Height="650" Width="1100"
         MinHeight="400" MinWidth="700"
@@ -63,10 +64,20 @@
                 <ListBox ItemsSource="{Binding ClientList.Clients}"
                          SelectedItem="{Binding ClientList.SelectedRow}"
                          BorderThickness="0"
-                         Background="Transparent">
+                         Background="Transparent"
+                         behaviors:ListBoxDragDropReorderBehavior.ReorderCommand="{Binding ClientList.ReorderCommand}">
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <StackPanel Margin="4,3">
+                                <StackPanel.Style>
+                                    <Style TargetType="StackPanel">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsActive}" Value="False">
+                                                <Setter Property="Opacity" Value="0.45"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </StackPanel.Style>
                                 <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
                                 <TextBlock Text="{Binding CompanyName}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}"/>
                             </StackPanel>
@@ -129,9 +140,6 @@
                                Text="{Binding ClientDetail.Client.Name}"
                                FontSize="18" FontWeight="Bold"
                                VerticalAlignment="Center"/>
-                    <Button Grid.Row="1" Grid.Column="1" Content="Delete client"
-                            Command="{Binding ClientList.DeleteClientCommand}"
-                            Style="{StaticResource DangerButton}"/>
                 </Grid>
                 <TabControl SelectedIndex="{Binding ClientDetail.SelectedTabIndex}"
                             Margin="8,0,8,8">

--- a/src/WorkTracking.UI/ViewModels/AppSettingsViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/AppSettingsViewModel.cs
@@ -10,8 +10,11 @@ public class AppSettingsViewModel(
     ISettingRepository settingRepository) : ViewModelBase
 {
     private const string ThemeSettingKey = "ui_theme";
+    private const string ShowDeactivatedClientsKey = "show_deactivated_clients";
 
     private AppTheme _selectedTheme = themeService.CurrentTheme;
+    private bool _showDeactivatedClients;
+
     public AppTheme SelectedTheme
     {
         get => _selectedTheme;
@@ -20,6 +23,12 @@ public class AppSettingsViewModel(
             if (SetField(ref _selectedTheme, value))
                 PreviewTheme(value);
         }
+    }
+
+    public bool ShowDeactivatedClients
+    {
+        get => _showDeactivatedClients;
+        set => SetField(ref _showDeactivatedClients, value);
     }
 
     public IReadOnlyList<AppTheme> AvailableThemes { get; } = [AppTheme.Light, AppTheme.Dark];
@@ -34,7 +43,11 @@ public class AppSettingsViewModel(
         else
             _selectedTheme = AppTheme.Light;
 
+        var showDeactivated = await settingRepository.GetAsync(ShowDeactivatedClientsKey);
+        _showDeactivatedClients = showDeactivated == "true";
+
         OnPropertyChanged(nameof(SelectedTheme));
+        OnPropertyChanged(nameof(ShowDeactivatedClients));
         themeService.Apply(_selectedTheme);
     }
 
@@ -44,5 +57,6 @@ public class AppSettingsViewModel(
     {
         themeService.Apply(_selectedTheme);
         await settingRepository.SetAsync(ThemeSettingKey, _selectedTheme.ToString());
+        await settingRepository.SetAsync(ShowDeactivatedClientsKey, _showDeactivatedClients ? "true" : "false");
     }
 }

--- a/src/WorkTracking.UI/ViewModels/ClientDetailViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/ClientDetailViewModel.cs
@@ -35,7 +35,7 @@ public class ClientDetailViewModel(
         Client = client;
         OnPropertyChanged(nameof(HasClient));
         SelectedTabIndex = 0;
-        _ = Timesheet.LoadAsync(client.Id, client.HourlyRate, client.InvoiceCapAmount);
+        _ = Timesheet.LoadAsync(client.Id, client.HourlyRate, client.InvoiceCapAmount, client.IsActive);
         _ = Invoices.LoadAsync(client.Id);
         _ = Summary.LoadAsync(client);
         _ = Settings.LoadAsync(client);
@@ -48,7 +48,7 @@ public class ClientDetailViewModel(
         {
             Client = updatedClient;
             OnPropertyChanged(nameof(HasClient));
-            _ = Timesheet.LoadAsync(updatedClient.Id, updatedClient.HourlyRate, updatedClient.InvoiceCapAmount);
+            _ = Timesheet.LoadAsync(updatedClient.Id, updatedClient.HourlyRate, updatedClient.InvoiceCapAmount, updatedClient.IsActive);
             _ = Summary.LoadAsync(updatedClient);
         };
     }

--- a/src/WorkTracking.UI/ViewModels/ClientListViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/ClientListViewModel.cs
@@ -10,7 +10,8 @@ namespace WorkTracking.UI.ViewModels;
 public class ClientListViewModel(
     IClientRepository clientRepository,
     IWorkEntryRepository workEntryRepository,
-    IDialogService dialogService) : ViewModelBase
+    IDialogService dialogService,
+    AppSettingsViewModel appSettings) : ViewModelBase
 {
     private ObservableCollection<ClientRowViewModel> _clients = [];
     private ClientRowViewModel? _selectedRow;
@@ -58,6 +59,34 @@ public class ClientListViewModel(
 
     public ICommand LoadClientsCommand => new RelayCommand(async _ => await LoadAsync());
 
+    public ICommand ReorderCommand => new RelayCommand(
+        async param =>
+        {
+            if (param is not (int fromIndex, int toIndex)) return;
+            await MoveClientAsync(fromIndex, toIndex);
+        });
+
+    private async Task MoveClientAsync(int fromIndex, int toIndex)
+    {
+        if (fromIndex < 0 || toIndex < 0 || fromIndex >= Clients.Count || toIndex >= Clients.Count) return;
+
+        var item = Clients[fromIndex];
+        Clients.RemoveAt(fromIndex);
+        Clients.Insert(toIndex, item);
+        OnPropertyChanged(nameof(HasClients));
+
+        var movedClient = _allClients.FirstOrDefault(r => r.Client.Id == item.Client.Id);
+        if (movedClient is not null)
+        {
+            _allClients.Remove(movedClient);
+            var insertAt = toIndex < _allClients.Count ? toIndex : _allClients.Count;
+            _allClients.Insert(insertAt, movedClient);
+        }
+
+        var orderedIds = Clients.Select(r => r.Client.Id).ToList();
+        await clientRepository.ReorderAsync(orderedIds);
+    }
+
     public ICommand AddClientCommand => new RelayCommand(async _ =>
     {
         var vm = new AddClientViewModel();
@@ -90,7 +119,8 @@ public class ClientListViewModel(
 
     public async Task LoadAsync()
     {
-        var clients = await clientRepository.GetAllAsync();
+        var includeInactive = appSettings.ShowDeactivatedClients;
+        var clients = await clientRepository.GetAllAsync(includeInactive);
         var hoursByClient = await workEntryRepository.GetUninvoicedHoursByClientAsync();
 
         _allClients = clients

--- a/src/WorkTracking.UI/ViewModels/ClientRowViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/ClientRowViewModel.cs
@@ -9,6 +9,7 @@ public class ClientRowViewModel(Client client, decimal uninvoicedHours)
     public Client Client => client;
     public string Name => client.Name;
     public string? CompanyName => client.CompanyName;
+    public bool IsActive => client.IsActive;
 
     public bool IsCapExceeded =>
         InvoiceCapCalculator.Calculate(

--- a/src/WorkTracking.UI/ViewModels/ClientSettingsViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/ClientSettingsViewModel.cs
@@ -4,6 +4,7 @@ using WorkTracking.Core.Models;
 using WorkTracking.Data.Repositories.Interfaces;
 using WorkTracking.UI.Commands;
 using WorkTracking.UI.Services;
+using CommandManager = System.Windows.Input.CommandManager;
 
 namespace WorkTracking.UI.ViewModels;
 
@@ -116,9 +117,49 @@ public class ClientSettingsViewModel(
 
     public ObservableCollection<CategoryToggleViewModel> Categories { get; } = [];
 
+    public bool IsActive => _client?.IsActive ?? true;
+    public bool IsReadOnly => !IsActive;
+
     public ICommand SaveCommand => new RelayCommand(
         async _ => await SaveAsync(),
-        _ => IsDirty && !IsSaving && !string.IsNullOrWhiteSpace(_name));
+        _ => IsDirty && !IsSaving && !string.IsNullOrWhiteSpace(_name) && IsActive);
+
+    public ICommand DeactivateCommand => new RelayCommand(
+        async _ =>
+        {
+            if (_client is null) return;
+            if (!dialogService.Confirm($"Deactivate '{_client.Name}'? They will be hidden from the client list.", "Deactivate Client")) return;
+            await clientRepository.SetActiveAsync(_client.Id, false);
+            _client.IsActive = false;
+            OnPropertyChanged(nameof(IsActive));
+            OnPropertyChanged(nameof(IsReadOnly));
+            CommandManager.InvalidateRequerySuggested();
+            ClientUpdated?.Invoke(this, _client);
+        },
+        _ => IsActive);
+
+    public ICommand ReactivateCommand => new RelayCommand(
+        async _ =>
+        {
+            if (_client is null) return;
+            await clientRepository.SetActiveAsync(_client.Id, true);
+            _client.IsActive = true;
+            OnPropertyChanged(nameof(IsActive));
+            OnPropertyChanged(nameof(IsReadOnly));
+            CommandManager.InvalidateRequerySuggested();
+            ClientUpdated?.Invoke(this, _client);
+        },
+        _ => !IsActive);
+
+    public ICommand DeleteClientCommand => new RelayCommand(
+        async _ =>
+        {
+            if (_client is null) return;
+            if (!dialogService.Confirm($"Delete client '{_client.Name}'? This cannot be undone.", "Delete Client")) return;
+            await clientRepository.DeleteAsync(_client.Id);
+            ClientDeleted?.Invoke(this, EventArgs.Empty);
+        },
+        _ => !IsActive);
 
     public string NewCategoryName
     {
@@ -138,6 +179,7 @@ public class ClientSettingsViewModel(
         _ => !string.IsNullOrWhiteSpace(_newCategoryName));
 
     public event EventHandler<Client>? ClientUpdated;
+    public event EventHandler? ClientDeleted;
 
     public async Task LoadAsync(Client client)
     {
@@ -168,6 +210,9 @@ public class ClientSettingsViewModel(
         }
 
         IsDirty = false;
+        OnPropertyChanged(nameof(IsActive));
+        OnPropertyChanged(nameof(IsReadOnly));
+        CommandManager.InvalidateRequerySuggested();
     }
 
     public async Task SaveAsync()

--- a/src/WorkTracking.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/MainWindowViewModel.cs
@@ -53,6 +53,21 @@ public class MainWindowViewModel(
             await Home.LoadAsync();
             ClientList.SelectedClient = updatedClient;
         };
+
+        ClientDetail.Settings.ClientDeleted += async (_, _) =>
+        {
+            ClientList.SelectedClient = null;
+            ClientDetail.Clear();
+            await ClientList.LoadAsync();
+            await Home.LoadAsync();
+            NotifyPanelState();
+        };
+
+        AppSettings.PropertyChanged += async (_, e) =>
+        {
+            if (e.PropertyName == nameof(AppSettingsViewModel.ShowDeactivatedClients))
+                await ClientList.LoadAsync();
+        };
     }
 
     private void NavigateHome()

--- a/src/WorkTracking.UI/ViewModels/TimesheetViewModel.cs
+++ b/src/WorkTracking.UI/ViewModels/TimesheetViewModel.cs
@@ -28,6 +28,7 @@ public class TimesheetViewModel(
     private int _clientId;
     private decimal _hourlyRate;
     private decimal? _invoiceCapAmount;
+    private bool _isClientActive = true;
 
     private ObservableCollection<WorkEntryRowViewModel> _entries = [];
     private ICollectionView? _entriesView;
@@ -322,6 +323,7 @@ public class TimesheetViewModel(
 
     public ICommand AddEntryCommand => new RelayCommand(async _ =>
     {
+        if (!_isClientActive) return;
         var enabledCategories = CategoriesWithAll.Skip(1).ToList();
         var vm = new WorkEntryDialogViewModel(enabledCategories);
         if (!dialogService.ShowWorkEntryDialog(vm)) return;
@@ -345,17 +347,17 @@ public class TimesheetViewModel(
         {
             dialogService.ShowError($"Failed to add entry: {ex.Message}");
         }
-    });
+    }, _ => _isClientActive);
 
-    public bool CanEditSelectedEntry => _selectedEntry is not null && !_selectedEntry.IsInvoiced;
-    public string EditOrViewButtonLabel => _selectedEntry?.IsInvoiced == true ? "View" : "Edit";
+    public bool CanEditSelectedEntry => _selectedEntry is not null && !_selectedEntry.IsInvoiced && _isClientActive;
+    public string EditOrViewButtonLabel => _selectedEntry?.IsInvoiced == true ? "View" : (!_isClientActive ? "View" : "Edit");
 
     public ICommand EditOrViewEntryCommand => new RelayCommand(
         async _ =>
         {
             if (_selectedEntry is null) return;
             var enabledCategories = CategoriesWithAll.Skip(1).ToList();
-            var isReadOnly = _selectedEntry.IsInvoiced;
+            var isReadOnly = _selectedEntry.IsInvoiced || !_isClientActive;
             var vm = new WorkEntryDialogViewModel(enabledCategories, _selectedEntry.Entry, isReadOnly: isReadOnly);
             if (isReadOnly)
             {
@@ -397,7 +399,7 @@ public class TimesheetViewModel(
                 dialogService.ShowError($"Failed to delete entry: {ex.Message}");
             }
         },
-        _ => _selectedEntry is not null && !_selectedEntry.IsInvoiced);
+        _ => _selectedEntry is not null && !_selectedEntry.IsInvoiced && _isClientActive);
 
     public ICommand ViewEntryCommand => new RelayCommand(
         _ =>
@@ -514,11 +516,12 @@ public class TimesheetViewModel(
 
     // --- Data loading ---
 
-    public async Task LoadAsync(int clientId, decimal hourlyRate, decimal? invoiceCapAmount)
+    public async Task LoadAsync(int clientId, decimal hourlyRate, decimal? invoiceCapAmount, bool isClientActive = true)
     {
         _clientId = clientId;
         _hourlyRate = hourlyRate;
         _invoiceCapAmount = invoiceCapAmount;
+        _isClientActive = isClientActive;
 
         var categories = await workCategoryRepository.GetByClientAsync(clientId);
         Categories = [.. categories];

--- a/src/WorkTracking.UI/Views/AppSettingsView.xaml
+++ b/src/WorkTracking.UI/Views/AppSettingsView.xaml
@@ -33,6 +33,20 @@
                                  ConverterParameter=Dark}"/>
             </StackPanel>
 
+            <!-- Clients -->
+            <TextBlock Text="Clients"
+                       Style="{StaticResource SectionHeader}"
+                       Margin="0,20,0,10"/>
+
+            <CheckBox Content="Show deactivated clients"
+                      FontSize="13"
+                      Foreground="{DynamicResource TextPrimaryBrush}"
+                      IsChecked="{Binding ShowDeactivatedClients}"/>
+            <TextBlock Text="When enabled, deactivated clients appear in the sidebar and search (greyed out). Their data is read-only."
+                       Foreground="{DynamicResource TextSecondaryBrush}"
+                       FontSize="11" TextWrapping="Wrap"
+                       Margin="20,4,0,0"/>
+
             <!-- Save -->
             <Button Content="Save settings"
                     Command="{Binding SaveCommand}"

--- a/src/WorkTracking.UI/Views/ClientSettingsView.xaml
+++ b/src/WorkTracking.UI/Views/ClientSettingsView.xaml
@@ -10,6 +10,28 @@
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="24,20" MaxWidth="560">
 
+            <!-- Deactivated banner -->
+            <Border Background="{DynamicResource SurfaceAltBrush}"
+                    BorderBrush="{DynamicResource BorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="4"
+                    Padding="12,8"
+                    Margin="0,0,0,16">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsActive}" Value="False">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <TextBlock Text="⚠ This client is deactivated. All settings are read-only."
+                           Foreground="{DynamicResource TextSecondaryBrush}"
+                           FontSize="12"/>
+            </Border>
+
             <!-- Client details -->
             <TextBlock Text="Client Details" Style="{StaticResource SectionHeader}" Margin="0,0,0,14"/>
 
@@ -31,37 +53,39 @@
 
                 <!-- Name -->
                 <TextBlock Grid.Row="0" Grid.Column="0" Text="Name *" VerticalAlignment="Center" Margin="0,0,0,8"/>
-                <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}" IsReadOnly="{Binding IsReadOnly}" Margin="0,0,0,8"/>
 
                 <!-- Contact name -->
                 <TextBlock Grid.Row="1" Grid.Column="0" Text="Contact name" VerticalAlignment="Center" Margin="0,0,0,8"/>
-                <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding ContactName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding ContactName, UpdateSourceTrigger=PropertyChanged}" IsReadOnly="{Binding IsReadOnly}" Margin="0,0,0,8"/>
 
                 <!-- Company name -->
                 <TextBlock Grid.Row="2" Grid.Column="0" Text="Company name" VerticalAlignment="Center" Margin="0,0,0,8"/>
-                <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding CompanyName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding CompanyName, UpdateSourceTrigger=PropertyChanged}" IsReadOnly="{Binding IsReadOnly}" Margin="0,0,0,8"/>
 
                 <!-- Address -->
                 <TextBlock Grid.Row="3" Grid.Column="0" Text="Address" VerticalAlignment="Top" Margin="0,4,0,8"/>
                 <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Address, UpdateSourceTrigger=PropertyChanged}"
                          AcceptsReturn="True" MinHeight="56" TextWrapping="Wrap"
+                         IsReadOnly="{Binding IsReadOnly}"
                          VerticalScrollBarVisibility="Auto" Margin="0,0,0,8"/>
 
                 <!-- ABN -->
                 <TextBlock Grid.Row="4" Grid.Column="0" Text="ABN" VerticalAlignment="Center" Margin="0,0,0,8"/>
-                <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Abn, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Abn, UpdateSourceTrigger=PropertyChanged}" IsReadOnly="{Binding IsReadOnly}" Margin="0,0,0,8"/>
 
                 <!-- Email -->
                 <TextBlock Grid.Row="5" Grid.Column="0" Text="Email" VerticalAlignment="Center" Margin="0,0,0,8"/>
-                <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Email, UpdateSourceTrigger=PropertyChanged}" IsReadOnly="{Binding IsReadOnly}" Margin="0,0,0,8"/>
 
                 <!-- Phone -->
                 <TextBlock Grid.Row="6" Grid.Column="0" Text="Phone" VerticalAlignment="Center" Margin="0,0,0,8"/>
-                <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding Phone, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding Phone, UpdateSourceTrigger=PropertyChanged}" IsReadOnly="{Binding IsReadOnly}" Margin="0,0,0,8"/>
 
                 <!-- Hourly rate -->
                 <TextBlock Grid.Row="7" Grid.Column="0" Text="Hourly rate *" VerticalAlignment="Center" Margin="0,0,0,8"/>
                 <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding HourlyRate, UpdateSourceTrigger=PropertyChanged, StringFormat='{}{0:F2}'}"
+                         IsReadOnly="{Binding IsReadOnly}"
                          Margin="0,0,0,8"/>
             </Grid>
 
@@ -82,6 +106,7 @@
                 <!-- Cap amount -->
                 <TextBlock Grid.Row="0" Grid.Column="0" Text="Invoice cap ($)" VerticalAlignment="Center" Margin="0,0,0,8"/>
                 <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding InvoiceCapAmount, UpdateSourceTrigger=PropertyChanged, TargetNullValue=''}"
+                         IsReadOnly="{Binding IsReadOnly}"
                          Margin="0,0,0,8"/>
 
                 <!-- Cap behavior -->
@@ -89,11 +114,13 @@
                 <ComboBox Grid.Row="1" Grid.Column="1"
                           ItemsSource="{x:Static vm:ClientSettingsViewModel.CapBehaviorOptions}"
                           SelectedItem="{Binding InvoiceCapBehavior}"
+                          IsEnabled="{Binding IsActive}"
                           Margin="0,0,0,8"/>
 
                 <!-- Frequency -->
                 <TextBlock Grid.Row="2" Grid.Column="0" Text="Invoice every (days)" VerticalAlignment="Center" Margin="0,0,0,8"/>
                 <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding InvoiceFrequencyDays, UpdateSourceTrigger=PropertyChanged, TargetNullValue=''}"
+                         IsReadOnly="{Binding IsReadOnly}"
                          Margin="0,0,0,8"/>
             </Grid>
 
@@ -102,7 +129,7 @@
             <TextBlock Text="Only enabled categories appear in the timesheet filter and entry form."
                        Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11" Margin="0,0,0,10"/>
 
-            <ItemsControl ItemsSource="{Binding Categories}">
+            <ItemsControl ItemsSource="{Binding Categories}" IsEnabled="{Binding IsActive}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate DataType="{x:Type vm:CategoryToggleViewModel}">
                         <CheckBox Content="{Binding Name}"
@@ -112,8 +139,9 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
-            <!-- Add new category -->
-            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+            <!-- Add new category (active clients only) -->
+            <StackPanel Orientation="Horizontal" Margin="0,8,0,0"
+                        Visibility="{Binding IsActive, Converter={StaticResource BoolToVisibilityConverter}}">
                 <TextBox Text="{Binding NewCategoryName, UpdateSourceTrigger=PropertyChanged}"
                          Width="180" Padding="4,3" Margin="0,0,6,0"
                          ToolTip="New category name"/>
@@ -123,8 +151,9 @@
                         Padding="10,5"/>
             </StackPanel>
 
-            <!-- Save -->
-            <StackPanel Orientation="Horizontal" Margin="0,20,0,0">
+            <!-- Save / Deactivate (active clients) -->
+            <StackPanel Orientation="Horizontal" Margin="0,20,0,0"
+                        Visibility="{Binding IsActive, Converter={StaticResource BoolToVisibilityConverter}}">
                 <Button Content="Save changes"
                         Command="{Binding SaveCommand}"
                         Style="{StaticResource PrimaryButton}"
@@ -141,6 +170,25 @@
                         </Style>
                     </TextBlock.Style>
                 </TextBlock>
+                <Button Content="Deactivate client"
+                        Command="{Binding DeactivateCommand}"
+                        Style="{StaticResource SecondaryButton}"
+                        Foreground="{DynamicResource DangerBrush}"
+                        Padding="14,6" Margin="16,0,0,0"/>
+            </StackPanel>
+
+            <!-- Reactivate / Delete (inactive clients) -->
+            <StackPanel Orientation="Horizontal" Margin="0,20,0,0"
+                        Visibility="{Binding IsReadOnly, Converter={StaticResource BoolToVisibilityConverter}}">
+                <Button Content="Reactivate client"
+                        Command="{Binding ReactivateCommand}"
+                        Style="{StaticResource PrimaryButton}"
+                        Padding="14,6" Margin="0,0,10,0"/>
+                <Button Content="Delete client"
+                        Command="{Binding DeleteClientCommand}"
+                        Style="{StaticResource SecondaryButton}"
+                        Foreground="{DynamicResource DangerBrush}"
+                        Padding="14,6"/>
             </StackPanel>
 
         </StackPanel>

--- a/tests/WorkTracking.Tests/UI/ClientListViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/ClientListViewModelTests.cs
@@ -19,7 +19,7 @@ public class ClientListViewModelTests
     private static Mock<IClientRepository> RepoWith(List<Client> clients)
     {
         var mock = new Mock<IClientRepository>();
-        mock.Setup(r => r.GetAllAsync()).ReturnsAsync(clients);
+        mock.Setup(r => r.GetAllAsync(It.IsAny<bool>())).ReturnsAsync(clients);
         return mock;
     }
 
@@ -30,8 +30,9 @@ public class ClientListViewModelTests
         return mock;
     }
 
+    private static AppSettingsViewModel MakeAppSettings() { var theme = new Mock<IThemeService>(); theme.Setup(t => t.CurrentTheme).Returns(AppTheme.Light); var settings = new Mock<ISettingRepository>(); settings.Setup(s => s.GetAsync(It.IsAny<string>())).ReturnsAsync((string?)null); return new AppSettingsViewModel(theme.Object, settings.Object); }
     private static ClientListViewModel MakeVm(List<Client> clients, Dictionary<int, decimal>? hours = null) =>
-        new(RepoWith(clients).Object, WorkEntryRepoWithHours(hours).Object, new Mock<IDialogService>().Object);
+        new(RepoWith(clients).Object, WorkEntryRepoWithHours(hours).Object, new Mock<IDialogService>().Object, MakeAppSettings());
 
     [Fact]
     public async Task LoadAsync_WithClients_PopulatesClients()

--- a/tests/WorkTracking.Tests/UI/CrudViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/CrudViewModelTests.cs
@@ -65,7 +65,16 @@ public class ClientListViewModelCrudTests
     {
         var workEntryMock = new Mock<IWorkEntryRepository>();
         workEntryMock.Setup(r => r.GetUninvoicedHoursByClientAsync()).ReturnsAsync(new Dictionary<int, decimal>());
-        return new(repo.Object, workEntryMock.Object, dialog.Object);
+        return new(repo.Object, workEntryMock.Object, dialog.Object, MakeAppSettings());
+    }
+
+    private static AppSettingsViewModel MakeAppSettings()
+    {
+        var theme = new Mock<IThemeService>();
+        theme.Setup(t => t.CurrentTheme).Returns(AppTheme.Light);
+        var settings = new Mock<ISettingRepository>();
+        settings.Setup(s => s.GetAsync(It.IsAny<string>())).ReturnsAsync((string?)null);
+        return new AppSettingsViewModel(theme.Object, settings.Object);
     }
 
     [Fact]
@@ -74,7 +83,7 @@ public class ClientListViewModelCrudTests
         var repo = new Mock<IClientRepository>();
         var dialog = new Mock<IDialogService>();
         var added = new Client { Id = 99, Name = "New Co", HourlyRate = 120m };
-        repo.Setup(r => r.GetAllAsync()).ReturnsAsync([added]);
+        repo.Setup(r => r.GetAllAsync(It.IsAny<bool>())).ReturnsAsync([added]);
         repo.Setup(r => r.AddAsync(It.IsAny<Client>())).ReturnsAsync(added);
         dialog.Setup(d => d.ShowAddClientDialog(It.IsAny<AddClientViewModel>()))
               .Callback<AddClientViewModel>(vm => { vm.Name = "New Co"; vm.HourlyRate = 120m; })
@@ -93,7 +102,7 @@ public class ClientListViewModelCrudTests
         var repo = new Mock<IClientRepository>();
         var dialog = new Mock<IDialogService>();
         dialog.Setup(d => d.ShowAddClientDialog(It.IsAny<AddClientViewModel>())).Returns(false);
-        repo.Setup(r => r.GetAllAsync()).ReturnsAsync([]);
+        repo.Setup(r => r.GetAllAsync(It.IsAny<bool>())).ReturnsAsync([]);
 
         var vm = MakeVm(repo, dialog);
         vm.AddClientCommand.Execute(null);
@@ -107,7 +116,7 @@ public class ClientListViewModelCrudTests
     {
         var client = new Client { Id = 1, Name = "Acme" };
         var repo = new Mock<IClientRepository>();
-        repo.Setup(r => r.GetAllAsync()).ReturnsAsync([]);
+        repo.Setup(r => r.GetAllAsync(It.IsAny<bool>())).ReturnsAsync([]);
         var dialog = new Mock<IDialogService>();
         dialog.Setup(d => d.Confirm(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
 

--- a/tests/WorkTracking.Tests/UI/MainWindowViewModelTests.cs
+++ b/tests/WorkTracking.Tests/UI/MainWindowViewModelTests.cs
@@ -13,10 +13,10 @@ public class MainWindowViewModelTests
     private static ClientListViewModel MakeClientListVm(List<Client>? clients = null)
     {
         var mock = new Mock<IClientRepository>();
-        mock.Setup(r => r.GetAllAsync()).ReturnsAsync(clients ?? []);
+        mock.Setup(r => r.GetAllAsync(It.IsAny<bool>())).ReturnsAsync(clients ?? []);
         var workEntryMock = new Mock<IWorkEntryRepository>();
         workEntryMock.Setup(r => r.GetUninvoicedHoursByClientAsync()).ReturnsAsync(new Dictionary<int, decimal>());
-        return new ClientListViewModel(mock.Object, workEntryMock.Object, new Mock<IDialogService>().Object);
+        return new ClientListViewModel(mock.Object, workEntryMock.Object, new Mock<IDialogService>().Object, MakeAppSettingsVm());
     }
 
     private static TimesheetViewModel MakeTimesheetVm()
@@ -72,7 +72,7 @@ public class MainWindowViewModelTests
     private static HomeViewModel MakeHomeVm()
     {
         var clientRepo = new Mock<IClientRepository>();
-        clientRepo.Setup(r => r.GetAllAsync()).ReturnsAsync([]);
+        clientRepo.Setup(r => r.GetAllAsync(It.IsAny<bool>())).ReturnsAsync([]);
         var entryRepo = new Mock<IWorkEntryRepository>();
         entryRepo.Setup(r => r.GetUninvoicedHoursByClientAsync()).ReturnsAsync(new Dictionary<int, decimal>());
         var invoiceRepo = new Mock<IInvoiceRepository>();

--- a/tests/WorkTracking.Tests/UI/Phase8Tests.cs
+++ b/tests/WorkTracking.Tests/UI/Phase8Tests.cs
@@ -12,13 +12,14 @@ namespace WorkTracking.Tests.UI;
 
 public class ClientListViewModelEmptyStateTests
 {
+    private static AppSettingsViewModel MakeAppSettings() { var theme = new Mock<IThemeService>(); theme.Setup(t => t.CurrentTheme).Returns(AppTheme.Light); var settings = new Mock<ISettingRepository>(); settings.Setup(s => s.GetAsync(It.IsAny<string>())).ReturnsAsync((string?)null); return new AppSettingsViewModel(theme.Object, settings.Object); }
     private static ClientListViewModel MakeVm(List<Client> clients)
     {
         var repo = new Mock<IClientRepository>();
-        repo.Setup(r => r.GetAllAsync()).ReturnsAsync(clients);
+        repo.Setup(r => r.GetAllAsync(It.IsAny<bool>())).ReturnsAsync(clients);
         var workEntryMock = new Mock<IWorkEntryRepository>();
         workEntryMock.Setup(r => r.GetUninvoicedHoursByClientAsync()).ReturnsAsync(new Dictionary<int, decimal>());
-        return new ClientListViewModel(repo.Object, workEntryMock.Object, new Mock<IDialogService>().Object);
+        return new ClientListViewModel(repo.Object, workEntryMock.Object, new Mock<IDialogService>().Object, MakeAppSettings());
     }
 
     [Fact]

--- a/website/docs/user-guide/clients.md
+++ b/website/docs/user-guide/clients.md
@@ -22,7 +22,7 @@ Each client has four tabs:
 | **Timesheet** | All work entries for this client |
 | **Invoices** | All invoice records |
 | **Summary** | Hours, revenue, and billing status |
-| **Settings** | Contact details and billing configuration |
+| **Settings** | Contact details, billing configuration, and client status |
 
 ---
 
@@ -32,9 +32,46 @@ Type in the search box above the client list to filter by name or company.
 
 ---
 
+## Reordering clients
+
+Drag any client row up or down to change its position in the list. The order is saved automatically and persists across restarts.
+
+---
+
+## Deactivating a client
+
+When a client engagement ends but you want to keep their history, deactivate them instead of deleting.
+
+1. Open the client and go to the **Settings** tab
+2. Click **Deactivate client**
+3. Confirm the prompt
+
+Deactivated clients:
+
+- Are hidden from the client list by default
+- Have all their timesheet, invoice, and summary data preserved
+- Are shown greyed out when "Show deactivated clients" is enabled in [App Settings](settings.md#app-settings)
+- Cannot have new time entries added or existing entries edited
+
+---
+
+## Reactivating a client
+
+1. Enable **Show deactivated clients** in App Settings (⚙ Settings in the sidebar)
+2. Select the deactivated client from the list
+3. Go to the **Settings** tab and click **Reactivate client**
+
+The client is immediately restored to full active status.
+
+---
+
 ## Deleting a client
 
-Click **Delete client** in the top-right of the client detail area. You will be asked to confirm before the client and all associated data is permanently removed.
+Deleting is permanent and removes all associated data. It is only available for **deactivated** clients as a safeguard.
+
+1. Deactivate the client first (see above)
+2. In the **Settings** tab, click **Delete client**
+3. Confirm the prompt
 
 !!! warning
     Deleting a client removes all their work entries, invoices, and settings. This cannot be undone.

--- a/website/docs/user-guide/index.md
+++ b/website/docs/user-guide/index.md
@@ -6,16 +6,16 @@ billid is organised around **clients**. Each client has their own timesheet, inv
 
 | Area | What it does |
 |---|---|
-| Left panel | Client list — search, select, or add clients |
+| Left panel | Client list — search, select, add, or drag to reorder clients |
 | Timesheet tab | Log and manage work entries |
 | Invoices tab | View invoice history |
 | Summary tab | Hours and revenue overview |
-| Settings tab | Client billing configuration |
+| Settings tab | Client billing configuration and status |
 
 ---
 
-- [Clients](clients.md) — creating and managing clients
+- [Clients](clients.md) — creating, managing, reordering, deactivating, and deleting clients
 - [Timesheet](timesheet.md) — logging work and preparing invoices
 - [Invoices](invoices.md) — viewing and managing invoice records
-- [Settings](settings.md) — configuring billing preferences
+- [Settings](settings.md) — configuring billing preferences and client status actions
 - [Exporting data](export.md) — exporting work entries to CSV

--- a/website/docs/user-guide/settings.md
+++ b/website/docs/user-guide/settings.md
@@ -1,6 +1,6 @@
 # Client Settings
 
-The **Settings** tab stores contact details and billing configuration for each client.
+The **Settings** tab stores contact details and billing configuration for each client. It also controls the client's active status.
 
 ---
 
@@ -42,3 +42,33 @@ To add a new category:
 ## Saving changes
 
 Click **Save changes** to persist any edits. Changes are not saved automatically.
+
+!!! note
+    All fields and the save button are read-only for deactivated clients.
+
+---
+
+## Client status actions
+
+### Deactivate client
+
+Ends the engagement and hides the client from the list while preserving all history. See [Deactivating a client](clients.md#deactivating-a-client) for full details.
+
+### Reactivate client
+
+Restores a deactivated client to full active status. Only visible when the client is currently deactivated. See [Reactivating a client](clients.md#reactivating-a-client).
+
+### Delete client
+
+Permanently removes the client and all associated data. Only available for deactivated clients. See [Deleting a client](clients.md#deleting-a-client).
+
+---
+
+## App Settings
+
+App-wide settings are accessible via **⚙ Settings** in the sidebar.
+
+| Setting | Notes |
+|---|---|
+| **Theme** | Choose Light or Dark theme |
+| **Show deactivated clients** | When enabled, deactivated clients appear greyed out in the client list |


### PR DESCRIPTION
## Summary

Closes #49

Implements full client lifecycle management: deactivation, reactivation, deletion, and manual ordering of the client list.

---

## What's changed

### Client deactivation & reactivation
- **Deactivate** a client from their Settings tab — hides them from the list and makes all their data read-only
- **Reactivate** from Settings tab (visible when client is inactive)
- Deactivated clients shown greyed out in the sidebar when 'Show deactivated clients' is enabled in App Settings
- Timesheet Add / Edit / Delete entry commands are all disabled for inactive clients

### Client deletion
- Delete is now a safeguarded two-step action: deactivate first, then delete from Settings tab
- Delete button removed from the main client header — it lives exclusively in the Settings tab
- Only available for deactivated clients

### Drag-to-reorder
- Clients in the left sidebar can be dragged up/down to set a custom order
- Order is persisted to the database via a new \sort_order\ column and survives restarts

### App Settings
- New 'Show deactivated clients' toggle — persisted to the \setting\ table
- Toggling the checkbox immediately reloads the client list (no save required)

---

## Migrations
- \migration_0003_add_client_is_active.sql\ — adds \is_active\ column (default 1)
- \migration_0004_add_client_sort_order.sql\ — adds \sort_order\ column, seeds from current alpha order

---

## Tests
All 204 existing tests pass. No regressions.

---

## Docs
Updated website user guide:
- \user-guide/clients.md\ — deactivation, reactivation, drag-to-reorder, updated delete flow
- \user-guide/settings.md\ — client status actions, App Settings section
- \user-guide/index.md\ — updated navigation table and section links